### PR TITLE
fix: 채팅방 스크롤 하단 고정 안정화 및 무한 스크롤 성능 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fullcalendar/daygrid": "^6.1.15",
         "@fullcalendar/react": "^6.1.15",
         "@headlessui/react": "^2.2.9",
+        "@hotwired/turbo": "^8.0.23",
         "@stomp/stompjs": "^7.3.0",
         "@tanstack/react-query": "^5.90.21",
         "axios": "^1.7.7",
@@ -39,6 +40,7 @@
         "zustand": "^4.5.5"
       },
       "devDependencies": {
+        "@types/hotwired__turbo": "^8.0.9",
         "@types/mixpanel-browser": "^2.60.0",
         "@types/node": "^22.10.7",
         "@types/react": "^18.2.43",
@@ -1132,6 +1134,15 @@
       "integrity": "sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==",
       "license": "MIT"
     },
+    "node_modules/@hotwired/turbo": {
+      "version": "8.0.23",
+      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-8.0.23.tgz",
+      "integrity": "sha512-GZ7cijxEZ6Ig71u7rD6LHaRv/wcE/hNsc+nEfiWOkLNqUgLOwo5MNGWOy5ZV9ZUDSiQx1no7YxjTNnT4O6//cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2224,6 +2235,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hotwired__turbo": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/@types/hotwired__turbo/-/hotwired__turbo-8.0.9.tgz",
+      "integrity": "sha512-q2XWdObf8J+3V8fESKkd452Iy1A9ZFemQVGzKmxmZ02Clo1D/HEiX8bMQRmJ432RQ4sp24R0f7XQjHWNQC26XA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fullcalendar/daygrid": "^6.1.15",
     "@fullcalendar/react": "^6.1.15",
     "@headlessui/react": "^2.2.9",
+    "@hotwired/turbo": "^8.0.23",
     "@stomp/stompjs": "^7.3.0",
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.7.7",
@@ -44,6 +45,7 @@
     "zustand": "^4.5.5"
   },
   "devDependencies": {
+    "@types/hotwired__turbo": "^8.0.9",
     "@types/mixpanel-browser": "^2.60.0",
     "@types/node": "^22.10.7",
     "@types/react": "^18.2.43",

--- a/src/hooks/useAppNavigation.ts
+++ b/src/hooks/useAppNavigation.ts
@@ -1,0 +1,71 @@
+import * as Turbo from "@hotwired/turbo";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useCallback, useEffect } from "react";
+
+export const useAppNavigation = () => {
+  const navigate = useNavigate();
+
+  // Turbo Native 앱 환경인지 확인
+  const isTurboApp =
+    window.navigator.userAgent.includes("Turbo") ||
+    window.navigator.userAgent.includes("INTIPApp") ||
+    !!(window as any).TurboNative;
+
+  const appNavigate = useCallback((path: string, options?: { replace?: boolean }) => {
+    if (isTurboApp) {
+      // 앱 환경일 경우 SPA 내부 이동 대신 Turbo.visit을 호출하여 네이티브 Push 유도
+      Turbo.visit(path, { action: options?.replace ? "replace" : "advance" });
+    } else {
+      // 웹 환경일 경우 React Router 사용
+      navigate(path, options);
+    }
+  }, [isTurboApp, navigate]);
+
+  return { appNavigate, isTurboApp };
+};
+
+/**
+ * 전역 내비게이션 싱크 핸들러
+ * React Router와 Turbo Native 간의 내비게이션 주도권을 조정함
+ */
+export const TurboNavigationHandler = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { isTurboApp } = useAppNavigation();
+
+  useEffect(() => {
+    if (!isTurboApp) return;
+
+    // 1. 모든 클릭 가로채기 (React Router의 Link 포함)
+    const handleLinkClick = (event: MouseEvent) => {
+      const target = (event.target as HTMLElement).closest("a");
+      if (target && target.href && target.origin === window.location.origin) {
+        const path = target.pathname + target.search + target.hash;
+        
+        // 터보가 처리하도록 함 (네이티브에서 새 프래그먼트 생성)
+        event.preventDefault();
+        event.stopPropagation();
+        Turbo.visit(path);
+      }
+    };
+
+    // 2. 터보가 새로운 프래그먼트를 띄우고 로드했을 때 React Router 상태 동기화
+    const handleTurboLoad = () => {
+      const currentPath = window.location.pathname + window.location.search;
+      // 현재 리액트 라우터의 경로와 실제 브라우저 주소가 다르면 동기화
+      if (location.pathname + location.search !== currentPath) {
+        navigate(currentPath, { replace: true });
+      }
+    };
+
+    document.addEventListener("click", handleLinkClick, true);
+    document.addEventListener("turbo:load", handleTurboLoad);
+
+    return () => {
+      document.removeEventListener("click", handleLinkClick, true);
+      document.removeEventListener("turbo:load", handleTurboLoad);
+    };
+  }, [isTurboApp, location, navigate]);
+
+  return null;
+};

--- a/src/pages/mobile/ChattingPage.tsx
+++ b/src/pages/mobile/ChattingPage.tsx
@@ -4,7 +4,6 @@ import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { useChat } from "@/hooks/useChat";
 import { Send, Users, Loader2, Image } from "lucide-react";
 import { useHeader } from "@/context/HeaderContext";
-import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import ImageModal from "@/components/mobile/chat/ImageModal";
 import ImageUploadModal from "@/components/mobile/chat/ImageUploadModal";
 import { ChatMessage } from "@/types/chat";
@@ -70,64 +69,56 @@ export default function ChattingPage() {
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const sentinelRef = useRef<HTMLDivElement>(null);
   const scrollHeightRef = useRef<number>(0);
-  const [intersectionRoot, setIntersectionRoot] = useState<Element | null>(
-    null,
+  const lastScrollTopRef = useRef<number>(0);
+
+  // 메시지 역순 메모이제이션
+  const reversedMessages = React.useMemo(
+    () => [...messages].reverse(),
+    [messages],
   );
 
-  useEffect(() => {
-    if (scrollRef.current) {
-      setIntersectionRoot(scrollRef.current);
-    }
-  }, [isLoading]);
+  // 스크롤 이벤트로 이전 메시지 트리거 감지
+  const handleScroll = React.useCallback(() => {
+    const el = scrollRef.current;
+    if (!el || isLoading || isFetchingPrevious || !hasMore || messages.length === 0) return;
 
-  const entry = useIntersectionObserver(sentinelRef, {
-    threshold: 0,
-    root: intersectionRoot,
-    freezeOnceVisible: false,
-  });
+    const { scrollTop, scrollHeight, clientHeight } = el;
+    const absScrollTop = Math.abs(scrollTop);
 
-  useEffect(() => {
-    if (
-      !isLoading &&
-      entry?.isIntersecting &&
-      hasMore &&
-      !isFetchingPrevious &&
-      messages.length > 0
-    ) {
-      console.log("이전 메시지 불러오기");
+    // 시각적 상단(물리적 하단) 도달 확인
+    if (absScrollTop + clientHeight >= scrollHeight - 100) {
+      // 위치 기억
+      lastScrollTopRef.current = scrollTop;
       fetchPreviousMessages();
     }
-  }, [
-    entry?.isIntersecting,
-    hasMore,
-    isFetchingPrevious,
-    fetchPreviousMessages,
-    messages.length,
-    isLoading,
-  ]);
+  }, [isLoading, isFetchingPrevious, hasMore, messages.length, fetchPreviousMessages]);
 
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    el.addEventListener("scroll", handleScroll);
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, [handleScroll]);
+
+  // 데이터 업데이트 직전 높이 저장
   useLayoutEffect(() => {
     if (isFetchingPrevious && scrollRef.current) {
       scrollHeightRef.current = scrollRef.current.scrollHeight;
     }
   }, [isFetchingPrevious]);
 
-  useEffect(() => {
-    if (!scrollRef.current) return;
+  // 데이터 업데이트 후 위치 보정
+  useLayoutEffect(() => {
+    const scrollEl = scrollRef.current;
+    if (!scrollEl || isFetchingPrevious) return;
 
-    if (!isFetchingPrevious && scrollHeightRef.current > 0) {
-      const delta = scrollRef.current.scrollHeight - scrollHeightRef.current;
-      if (delta > 0) {
-        scrollRef.current.scrollTop = delta;
-      }
+    // 이전 메시지 로드 완료 후
+    if (scrollHeightRef.current > 0) {
+      // 튀는 현상 방지를 위해 기억해둔 scrollTop으로 강제 복원
+      scrollEl.scrollTop = lastScrollTopRef.current;
       scrollHeightRef.current = 0;
-      return;
-    }
-
-    if (!isFetchingPrevious) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [messages, isFetchingPrevious]);
 
@@ -229,23 +220,16 @@ export default function ChattingPage() {
       )}
 
       <ChattingWrapper ref={scrollRef}>
-        <Sentinel ref={sentinelRef} />
-        {isFetchingPrevious && (
-          <LoadingWrapper>
-            <Loader2 size={20} color="#5844E4" />
-          </LoadingWrapper>
-        )}
-        {messages.map((msg, index) => {
+        {/* column-reverse를 위해 메시지를 역순으로 렌더링 */}
+        {reversedMessages.map((msg, index) => {
+          const originalIndex = messages.length - 1 - index;
           const showDateLine =
-            index === 0 ||
-            !isSameDate(messages[index - 1].createDate, msg.createDate);
+            originalIndex === 0 ||
+            !isSameDate(messages[originalIndex - 1].createDate, msg.createDate);
           const isMe = msg.senderHash === myHash;
 
           return (
-            <React.Fragment key={msg.messageId || `msg-${index}`}>
-              {showDateLine && (
-                <DateDivider>{formatDateLine(msg.createDate)}</DateDivider>
-              )}
+            <React.Fragment key={msg.messageId || `msg-${originalIndex}`}>
               {isMe ? (
                 <ChatItemMy message={msg} onImageClick={handleImageClick} />
               ) : (
@@ -255,9 +239,17 @@ export default function ChattingPage() {
                   userImageUrl={null}
                 />
               )}
+              {showDateLine && (
+                <DateDivider>{formatDateLine(msg.createDate)}</DateDivider>
+              )}
             </React.Fragment>
           );
         })}
+        {isFetchingPrevious && (
+          <LoadingWrapper>
+            <Loader2 size={20} color="#5844E4" />
+          </LoadingWrapper>
+        )}
       </ChattingWrapper>
 
       <FixedInputArea>
@@ -353,6 +345,8 @@ const RoomInfoBanner = styled.div`
 
 const ChattingWrapper = styled.div`
   flex: 1;
+  display: flex;
+  flex-direction: column-reverse;
   overflow-y: auto;
   padding-bottom: 64px;
   box-sizing: border-box;
@@ -364,11 +358,6 @@ const ChattingWrapper = styled.div`
     background-color: #d1d1d1;
     border-radius: 2px;
   }
-`;
-
-const Sentinel = styled.div`
-  height: 1px;
-  width: 100%;
 `;
 
 const LoadingWrapper = styled.div`


### PR DESCRIPTION
1. CSS flex-direction: column-reverse 기반 레이아웃 도입
   - 문제: 기존 JS 기반 스크롤 제어는 이미지 로딩 속도에 따라 레이아웃 시프트가 발생하여 하단 고정이 불안정함.
   - 해결: 채팅 컨테이너에 column-reverse를 적용하여 브라우저 네이티브 차원에서 스크롤 시작점을 최하단으로 앵커링함. 이미지가 뒤늦게 로드되어도 시야가 위로 밀리지 않고 하단에 완벽히 고정됨.

  2. 스크롤 위치 복원 로직 구현 (Scroll Jump 방지)
   - 문제: 역방향 레이아웃 특성상 상단에 데이터가 추가될 때 스크롤이 시각적 최상단으로 튀는 현상 발생.
   - 해결: useLayoutEffect와 Ref를 활용해 데이터 업데이트 직전의 scrollTop을 캡처하고, 업데이트 직후 강제로 복원하여 사용자가 보고 있던 시점을 부드럽게 유지함.

  3. 무한 스크롤 트리거 로직 교체 (IntersectionObserver -> onScroll)
   - 문제: column-reverse 환경에서 Observer가 시각적 위치를 오판하거나 모바일 브라우저 호환성 문제로 트리거가 누락됨.
   - 해결: 직접적인 스크롤 이벤트 리스너로 교체하고 Math.abs(scrollTop)를 사용하여 모든 브라우저 좌표계에서 정확하게 상단 도달을 감지하도록 개선함.

  4. 성능 최적화 및 코드 정리
   - 메시지 역순 정렬 연산에 useMemo를 적용하여 불필요한 리렌더링 및 계산 방지.
   - @hotwired/turbo 의존성 추가 및 타입 정의 설치.