### PR TITLE
Fix: 캠퍼스맵에서 지도 드래그,바텀시트 높이 조작 시 지도 버벅임 해결

### DIFF
--- a/src/components/map/components/KakaoMap.tsx
+++ b/src/components/map/components/KakaoMap.tsx
@@ -86,12 +86,9 @@ interface Props {
   selectedTab: string;
   viewXY: { X: number; Y: number };
   setMap: any;
-  setSelectedCoord?: React.Dispatch<
-    React.SetStateAction<{ X: number; Y: number }>
-  >;
+  setSelectedCoord?: (coord: { X: number; Y: number }, enableOffset?: boolean) => void;
   openedMarkerId: string | null;
   setOpenedMarkerId: (id: string | null, coord?: { X: number; Y: number }) => void;
-  offset?: number;
   isTracking?: boolean;
   setIsTracking?: (isTracking: boolean) => void;
 }
@@ -103,7 +100,6 @@ const KakaoMap = ({
   setSelectedCoord,
   openedMarkerId,
   setOpenedMarkerId,
-  offset = 0,
   isTracking = false,
   setIsTracking,
 }: Props) => {
@@ -117,38 +113,22 @@ const KakaoMap = ({
   const currentTab = selectedTab as TabType;
   const config = MAP_TAB_CONFIG[currentTab];
   
-  // 1. 지도의 중심을 로컬 상태로 관리 (인입런 방식)
-  const [mapCenter, setMapCenter] = useState({ lat: viewXY.X, lng: viewXY.Y });
+  // 지도의 중심을 ref로 관리하여 드래그 중/후 불필요한 동기화 레이스를 방지
+  const lastViewXYRef = useRef(viewXY);
+  const mapCenterRef = useRef({ lat: viewXY.X, lng: viewXY.Y });
+
+  if (
+    lastViewXYRef.current.X !== viewXY.X ||
+    lastViewXYRef.current.Y !== viewXY.Y
+  ) {
+    lastViewXYRef.current = viewXY;
+    mapCenterRef.current = { lat: viewXY.X, lng: viewXY.Y };
+  }
+  const mapLevelRef = useRef(4);
   const lastTargetRef = useRef(viewXY);
   
   const isDraggingRef = useRef(false);
-  const isSyncingCenterRef = useRef(false);
   const isAnimatingRef = useRef(false);
-  const lastOffsetRef = useRef(offset);
-
-  const syncSelectedCoordWithMapCenter = (targetOffset: number) => {
-    if (!mapInstance || !setSelectedCoord) return;
-
-    const center = mapInstance.getCenter();
-    const nextCoord = {
-      X: center.getLat() + targetOffset,
-      Y: center.getLng(),
-    };
-
-    isSyncingCenterRef.current = true;
-    setSelectedCoord((prev) => {
-      const isSame =
-        Math.abs(prev.X - nextCoord.X) < 0.00001 &&
-        Math.abs(prev.Y - nextCoord.Y) < 0.00001;
-
-      if (isSame) {
-        isSyncingCenterRef.current = false;
-        return prev;
-      }
-      
-      return nextCoord;
-    });
-  };
 
 
 
@@ -206,7 +186,7 @@ const KakaoMap = ({
     );
 
     return () => navigator.geolocation.clearWatch(watchId);
-  }, [isTracking, mapInstance, offset]);
+  }, [isTracking, mapInstance]);
 
   // 2. 기기 방향 감지
   useEffect(() => {
@@ -305,38 +285,42 @@ const KakaoMap = ({
     isDraggingRef.current = false;
     isAnimatingRef.current = false;
     if (isTracking && setIsTracking) setIsTracking(false);
+
+    if (mapInstance) {
+      const center = mapInstance.getCenter();
+      const lat = center.getLat();
+      const lng = center.getLng();
+
+      mapCenterRef.current = { lat, lng };
+      lastTargetRef.current = { X: lat, Y: lng };
+
+      const isSame =
+        Math.abs(viewXY.X - lat) < 0.00001 &&
+        Math.abs(viewXY.Y - lng) < 0.00001;
+
+      if (!isSame && setSelectedCoord) {
+        setSelectedCoord({ X: lat, Y: lng }, false);
+      }
+    }
   };
 
-  // 3. 외부 viewXY 및 offset 변경 감지 (인입런 구조 적용)
+  // 3. 외부 viewXY 변경 감지
   useLayoutEffect(() => {
     if (!mapInstance || isDraggingRef.current) return;
 
-    // 1. 바텀시트 조작(offset 변경) 감지 시 현재 위치 유지하며 부모 상태 동기화
-    if (Math.abs(lastOffsetRef.current - offset) > 0.0001) {
-      syncSelectedCoordWithMapCenter(lastOffsetRef.current);
-      lastOffsetRef.current = offset;
-      return;
-    }
-
-    // 2. 외부에서 좌표가 명시적으로 변경된 경우(장소 클릭 등)에만 이동
+    // 외부에서 좌표가 명시적으로 변경된 경우(장소 클릭 등)에만 이동
     const isExternalMove = 
       Math.abs(lastTargetRef.current.X - viewXY.X) > 0.00001 ||
       Math.abs(lastTargetRef.current.Y - viewXY.Y) > 0.00001;
 
     if (isExternalMove) {
-      if (isSyncingCenterRef.current) {
-        isSyncingCenterRef.current = false;
-        lastTargetRef.current = viewXY;
-        return;
-      }
-
       lastTargetRef.current = viewXY;
-      setMapCenter({ lat: viewXY.X, lng: viewXY.Y });
+      mapCenterRef.current = { lat: viewXY.X, lng: viewXY.Y };
       
       isAnimatingRef.current = true;
       mapInstance.panTo(new window.kakao.maps.LatLng(viewXY.X, viewXY.Y));
     }
-  }, [viewXY.X, viewXY.Y, offset, mapInstance]);
+  }, [viewXY.X, viewXY.Y, mapInstance]);
 
   const placesToRender = useMemo(() => {
     switch (currentTab) {
@@ -351,8 +335,8 @@ const KakaoMap = ({
   return (
     <Container>
       <Map
-        center={mapCenter}
-        level={4}
+        center={mapCenterRef.current}
+        level={mapLevelRef.current}
         draggable={true}
         zoomable={true}
         style={{ width: "100%", height: "100%" }}
@@ -367,6 +351,13 @@ const KakaoMap = ({
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onIdle={handleIdle}
+        onZoomChanged={(map) => {
+          mapLevelRef.current = map.getLevel();
+        }}
+        onCenterChanged={(map) => {
+          const center = map.getCenter();
+          mapCenterRef.current = { lat: center.getLat(), lng: center.getLng() };
+        }}
       >
         {placesToRender.map((place) => {
           const markerId = config.getMarkerId(place);

--- a/src/pages/mobile/MobileCampusPage.tsx
+++ b/src/pages/mobile/MobileCampusPage.tsx
@@ -36,6 +36,12 @@ export default function MobileCampusPage() {
       : false,
   );
   const [selectedCoord, setSelectedCoord] = useState<XY>(SCHOOL_COORD);
+  const [isOffsetEnabled, setIsOffsetEnabled] = useState(true);
+
+  const moveToCoord = (coord: XY, enableOffset = true) => {
+    setIsOffsetEnabled(enableOffset);
+    setSelectedCoord(coord);
+  };
 
   const location = useLocation();
 
@@ -54,7 +60,7 @@ export default function MobileCampusPage() {
     setSnap(BOTTOM_SHEET_HEIGHT.DEFAULT);
 
     if (coord) {
-      setSelectedCoord(coord);
+      moveToCoord(coord, true);
     }
   };
 
@@ -150,24 +156,20 @@ export default function MobileCampusPage() {
     };
   }, [isCampus]);
 
-  const offset = useMemo(() => {
-    if (isDesktop) {
-      return 0;
+  const viewXY = useMemo(() => {
+    if (isDesktop || !isOffsetEnabled) {
+      return {
+        X: selectedCoord.X,
+        Y: selectedCoord.Y,
+      };
     }
 
-    const currentSnap =
-      typeof snap === "number" ? snap : BOTTOM_SHEET_HEIGHT.DEFAULT;
-
-    return currentSnap * 0.0018;
-  }, [isDesktop, snap]);
-
-  const viewXY = useMemo(
-    () => ({
+    const offset = BOTTOM_SHEET_HEIGHT.DEFAULT * 0.0018;
+    return {
       X: selectedCoord.X - offset,
       Y: selectedCoord.Y,
-    }),
-    [selectedCoord, offset],
-  );
+    };
+  }, [selectedCoord, isDesktop, isOffsetEnabled]);
 
   return (
     <MobileCampusPageWrapper>
@@ -178,7 +180,7 @@ export default function MobileCampusPage() {
           selectedTab={selectedTab}
           setSelectedTab={setSelectedTab}
           map={map}
-          setSelectedCoord={setSelectedCoord}
+          setSelectedCoord={moveToCoord}
           openedMarkerId={openedMarkerId}
           setOpenedMarkerId={setOpenedMarkerId}
           snap={snap}
@@ -192,7 +194,7 @@ export default function MobileCampusPage() {
           selectedTab={selectedTab}
           viewXY={viewXY}
           setMap={setMap}
-          setSelectedCoord={setSelectedCoord}
+          setSelectedCoord={moveToCoord}
           openedMarkerId={openedMarkerId}
           setOpenedMarkerId={handleMarkerClick}
           isTracking={isTracking}
@@ -207,7 +209,7 @@ export default function MobileCampusPage() {
           selectedTab={selectedTab}
           setSelectedTab={setSelectedTab}
           map={map}
-          setSelectedCoord={setSelectedCoord}
+          setSelectedCoord={moveToCoord}
           openedMarkerId={openedMarkerId}
           setOpenedMarkerId={setOpenedMarkerId}
           snap={snap}


### PR DESCRIPTION
장소를 선택하는 클릭 시점에만 1회성으로 위치 보정(Offset)을 적용하고, 바텀시트를 끌어 올리거나 내릴 때는 지도가 제자리에서 고정되어 있도록 수정

- isOffsetEnabled 상태 도입 (MobileCampusPage.tsx)
지도의 보정 상태를 관리할 isOffsetEnabled 상태값과, 이동 시 보정 여부를 옵션으로 받는 moveToCoord(coord, enableOffset) 헬퍼 함수 추가
- 1회성 클릭 오프셋 적용
장소 리스트 클릭, 지도 핀 클릭, 탭 이동 및 현위치 아이콘 클릭 등 명시적인 장소 선택 이벤트 시에는 moveToCoord(coord, true)를 호출하여 오직 최초 1회만 지도를 오프셋만큼 아래로 보정하여 마커가 바텀시트 위에 들어오도록 이동
- 수동 드래그 시 오프셋 비활성화
사용자가 손으로 화면을 움직여 드래그/줌을 마쳤을 때는 handleIdle 콜백 내에서 setSelectedCoord(coord, false) 호출
이에 따라 isOffsetEnabled 상태가 즉시 false로 꺼지게 되며, 이후 바텀시트를 움직여도 지도의 오프셋 보정 루프가 돌지 않아 화면이 떨리지 않고 단단히 고정됨