### PR TITLE
Fix: 지도 내 핀 클릭 시 간헐적으로 화면 버벅이는 문제 수정

### DIFF
--- a/src/components/map/components/KakaoMap.tsx
+++ b/src/components/map/components/KakaoMap.tsx
@@ -355,6 +355,7 @@ const KakaoMap = ({
           mapLevelRef.current = map.getLevel();
         }}
         onCenterChanged={(map) => {
+          if (isAnimatingRef.current) return;
           const center = map.getCenter();
           mapCenterRef.current = { lat: center.getLat(), lng: center.getLng() };
         }}
@@ -382,15 +383,7 @@ const KakaoMap = ({
                       "Marker",
                     );
                   }
-                  setOpenedMarkerId(
-                    isOpen ? null : markerId,
-                    isOpen
-                      ? undefined
-                      : {
-                          X: Number(place.latitude),
-                          Y: Number(place.longitude),
-                        },
-                  );
+                  setOpenedMarkerId(isOpen ? null : markerId);
                   if (setIsTracking) setIsTracking(false);
                 }}
               />
@@ -442,7 +435,7 @@ const KakaoMap = ({
           </CustomOverlayMap>
         )}
 
-        {window.kakao?.maps && (
+        {window.kakao?.maps?.ControlPosition && (
           <MapTypeControl position={window.kakao.maps.ControlPosition.TOPRIGHT} />
         )}
       </Map>


### PR DESCRIPTION
- 핀 클릭 시 화면 이동 제거
핀을 눌렀을 때는 지도 카메라가 그 핀으로 강제 이동하지 않도록 변경하여 사용자가 보고 있던 시야 그대로 핀 정보창이 표시되도록 함