### PR TITLE
fix: iOS 공식 앱이 항상 OLD_APP으로 오판되는 환경 감지 버그 수정

### DIFF
--- a/src/utils/getMobilePlatform.ts
+++ b/src/utils/getMobilePlatform.ts
@@ -14,31 +14,31 @@ export type AppEnvironmentStatus = "NEW_APP" | "OLD_APP" | "BROWSER";
  */
 export function getAppEnvironmentStatus(): AppEnvironmentStatus {
   const userAgent = navigator.userAgent || "";
-  
-  // 1. 안드로이드 공식 앱 판정
-  const isAndroidUA = userAgent.includes("INTIPApp");
+
+  // 플랫폼 판별은 UA가 아니라 "주입된 브릿지 객체"로 한다.
+  // 네이티브 앱은 iOS/Android 공통으로 UA에 "INTIPApp" 접미사를 붙이므로
+  // (User-Agent 규격, 양 플랫폼 공통), UA의 "INTIPApp" 포함 여부를 안드로이드
+  // 신호로 사용하면 iOS 앱이 안드로이드 분기로 잘못 빠져 항상 OLD_APP으로 오판된다.
   const isAndroidBridgeExists = typeof window.AndroidBridge !== "undefined";
-  
-  if (isAndroidUA || isAndroidBridgeExists) {
-    // 신버전 안드로이드 앱은 navigateTo 함수가 존재함
-    if (typeof window.AndroidBridge?.navigateTo === "function") {
-      return "NEW_APP";
-    } else {
-      return "OLD_APP";
-    }
+  const isIOSBridgeExists =
+    typeof window.webkit?.messageHandlers?.requestAppUpdate !== "undefined";
+
+  // 1. iOS 공식 앱 판정 (AndroidBridge가 없고 webkit 브릿지가 존재하는 경우)
+  // 구버전 iOS 앱도 window.webkit.messageHandlers.requestAppUpdate는 가지고 있고,
+  // 신버전(멀티 웹뷰) iOS 앱만 navigateTo 핸들러를 노출한다.
+  if (!isAndroidBridgeExists && isIOSBridgeExists) {
+    return typeof window.webkit?.messageHandlers?.navigateTo !== "undefined"
+      ? "NEW_APP"
+      : "OLD_APP";
   }
 
-  // 2. iOS 공식 앱 판정
-  // 구버전 iOS 앱도 window.webkit.messageHandlers.requestAppUpdate는 가지고 있음
-  const isIOSBridgeExists = typeof window.webkit?.messageHandlers?.requestAppUpdate !== "undefined";
-  
-  if (isIOSBridgeExists) {
-    // 신버전 iOS 앱은 User-Agent에 INTIPApp을 달고 들어옴
-    if (userAgent.includes("INTIPApp")) {
-      return "NEW_APP";
-    } else {
-      return "OLD_APP";
-    }
+  // 2. 안드로이드 공식 앱 판정
+  // AndroidBridge 객체가 주입되었거나, (브릿지 주입 전 타이밍 대비) UA에 INTIPApp이 포함된 경우.
+  // 신버전 안드로이드 앱은 navigateTo 함수가 존재한다.
+  if (isAndroidBridgeExists || userAgent.includes("INTIPApp")) {
+    return typeof window.AndroidBridge?.navigateTo === "function"
+      ? "NEW_APP"
+      : "OLD_APP";
   }
 
   // 3. 일반 웹 브라우저 및 카카오톡/인스타 등 타사 인앱 브라우저


### PR DESCRIPTION
## 무엇이 문제였는지

`getAppEnvironmentStatus()`(`src/utils/getMobilePlatform.ts`)가 **iOS 공식 앱을 항상 `OLD_APP`으로 오판**합니다.

원인은 **UA 접미사 `INTIPApp`이 iOS/Android 공통**이라는 점입니다. (User-Agent 규격상 네이티브 앱은 양 플랫폼 공통으로 UA 끝에 ` INTIPApp/x.y.z`를 붙임)

기존 코드는 이 공통 접미사를 **안드로이드 신호**로 사용했습니다.

```ts
const isAndroidUA = userAgent.includes("INTIPApp");
const isAndroidBridgeExists = typeof window.AndroidBridge !== "undefined";

if (isAndroidUA || isAndroidBridgeExists) {        // ← iOS도 여기로 들어옴
  return typeof window.AndroidBridge?.navigateTo === "function"
    ? "NEW_APP" : "OLD_APP";                        // iOS엔 AndroidBridge가 없으므로 항상 OLD_APP
}
// iOS 분기(webkit.messageHandlers 검사)는 공식 iOS 앱에선 도달 불가
```

iOS 공식 앱은 UA에 `INTIPApp`이 있으므로 `isAndroidUA === true` → 안드로이드 분기로 진입 → `window.AndroidBridge`가 없어 `navigateTo`도 없음 → **무조건 `OLD_APP`**. 그 아래 iOS 분기(`window.webkit.messageHandlers.requestAppUpdate` 검사)는 **공식 iOS 앱에서 절대 실행되지 않습니다.**

### 영향
- `RootLayout`의 강제 업데이트 게이트가 `OLD_APP && VITE_FORCE_UPDATE_ENABLED` 조건이라, **iOS 앱은 항상 "업데이트 안내(→ 스토어)" 모달에 막힘.**
- `supportsMultiWebView()`(= `NEW_APP`)가 항상 false → **iOS에서 `appBridge.navigateTo`가 호출되지 않음** → 멀티 웹뷰 네이티브 푸시가 동작하지 않고 SPA 라우팅으로 폴백.
- 네이티브 앱 UA를 어떻게 바꿔도 해결 불가: `INTIPApp` 포함 시 → 안드로이드 분기 → `OLD_APP`, 미포함 시 → iOS 분기도 `INTIPApp` 없으므로 → `OLD_APP`.

## 어떻게 해결하는지

플랫폼 판별 기준을 **공유되는 UA 문자열이 아니라, 플랫폼별로 주입되는 브릿지 객체**로 변경합니다.

```ts
const isAndroidBridgeExists = typeof window.AndroidBridge !== "undefined";
const isIOSBridgeExists =
  typeof window.webkit?.messageHandlers?.requestAppUpdate !== "undefined";

// 1. iOS: AndroidBridge가 없고 webkit 브릿지가 존재
if (!isAndroidBridgeExists && isIOSBridgeExists) {
  return typeof window.webkit?.messageHandlers?.navigateTo !== "undefined"
    ? "NEW_APP" : "OLD_APP";      // navigateTo 핸들러 유무로 신/구버전 구분
}

// 2. Android: AndroidBridge 객체(또는 주입 전 타이밍 대비 UA)
if (isAndroidBridgeExists || userAgent.includes("INTIPApp")) {
  return typeof window.AndroidBridge?.navigateTo === "function"
    ? "NEW_APP" : "OLD_APP";
}

return "BROWSER";
```

핵심:
- **iOS를 먼저, `window.AndroidBridge` 부재 + `window.webkit.messageHandlers.requestAppUpdate` 존재**로 판정 → 공유 UA 접미사로 인한 오라우팅 제거.
- iOS 신/구버전은 **`navigateTo` 핸들러 노출 여부**로 구분 (멀티 웹뷰 지원 = 신버전).
- Android는 종전대로 `AndroidBridge`(객체) 기준. UA는 브릿지 주입 전 타이밍 대비 보조 신호로만 사용.

이 변경으로 멀티 웹뷰 브릿지를 노출하는 iOS 신버전 앱이 정상적으로 `NEW_APP`으로 판정되어, 강제 업데이트 게이트를 통과하고 `appBridge.navigateTo`가 호출됩니다.

> 참고: 네이티브(iOS) 측에는 별도의 동반 수정이 필요합니다. react-native-webview의 WKWebView에서는 `window.webkit.messageHandlers`에 핸들러를 **추가**해도 무시되므로, 앱 쉼(shim)이 `window.webkit`을 ReactNativeWebView 핸들러를 보존한 새 객체로 교체하도록 수정되어 있어야 `navigateTo`/`requestAppUpdate`가 노출됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)