### PR TITLE
fix: 상단 헤더 이중 safe-area 패딩 제거 및 바텀 네비게이션 동적 좌표 계산 보완

### DIFF
--- a/src/containers/mobile/common/MobileBottomNav.tsx
+++ b/src/containers/mobile/common/MobileBottomNav.tsx
@@ -180,13 +180,15 @@ export default function MobileBottomNav() {
     navigate(to, { replace: true });
   };
 
+  const validWidth = dimensions.width > 0 ? dimensions.width : (typeof window !== "undefined" && window.innerWidth > 0 ? window.innerWidth : 390);
+  const validHeight = dimensions.height > 0 ? dimensions.height : 88;
   const maxContentWidth = parseInt(DESKTOP_CONTENT_MAX_WIDTH, 10) || 1600;
-  const contentWidth = Math.min(dimensions.width, maxContentWidth);
-  const leftOffset = (dimensions.width - contentWidth) / 2;
+  const contentWidth = Math.min(validWidth, maxContentWidth);
+  const leftOffset = (validWidth - contentWidth) / 2;
 
   const activeX = leftOffset + ((activeIndex + 0.5) / 5) * contentWidth;
-  const pathD = getPath(dimensions.width, dimensions.height, activeX);
-  const lineD = getLinePath(dimensions.width, activeX);
+  const pathD = getPath(validWidth, validHeight, activeX);
+  const lineD = getLinePath(validWidth, activeX);
 
   return (
     <NavContainer ref={containerRef}>
@@ -195,7 +197,7 @@ export default function MobileBottomNav() {
         <svg
           width="100%"
           height="100%"
-          viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+          viewBox={`0 0 ${validWidth} ${validHeight}`}
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           style={{ overflow: "visible" }}
@@ -224,7 +226,7 @@ export default function MobileBottomNav() {
         <svg
           width="100%"
           height="100%"
-          viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+          viewBox={`0 0 ${validWidth} ${validHeight}`}
           preserveAspectRatio="none"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -243,7 +245,7 @@ export default function MobileBottomNav() {
         <svg
           width="100%"
           height="100%"
-          viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+          viewBox={`0 0 ${validWidth} ${validHeight}`}
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           style={{ overflow: "visible" }}

--- a/src/containers/mobile/common/MobileHeader.tsx
+++ b/src/containers/mobile/common/MobileHeader.tsx
@@ -187,11 +187,6 @@ const MobileHeaderWrapper = styled.header<{
   position: ${({ $contained }) => ($contained ? "relative" : "fixed")};
   top: ${({ $contained }) => ($contained ? "auto" : "0")};
   width: 100%;
-  /* Root's WebView is now edge-to-edge (native SafeAreaView removed for
-     root), so this must cover the notch/status bar itself. env() resolves
-     to 0 on sub-pages, where native still reserves the top inset, and on
-     desktop, which has no notch — so this is safe to apply unconditionally. */
-  padding-top: calc(20px + env(safe-area-inset-top, 0px));
   z-index: 1000;
   display: flex;
   flex-direction: column;
@@ -206,14 +201,14 @@ const MainHeaderWrapper = styled.div<{
   position: relative;
   z-index: 2;
   width: 100%;
-  height: calc(72px + env(safe-area-inset-top, 20px));
+  height: calc(56px + env(safe-area-inset-top, 0px));
   display: flex;
   justify-content: space-between;
   align-items: center;
   box-sizing: border-box;
   pointer-events: none;
 
-  padding-top: calc(16px + env(safe-area-inset-top, 20px));
+  padding-top: env(safe-area-inset-top, 0px);
   padding-left: ${({ $hasBack }) => ($hasBack ? "12px" : "20px")};
   padding-right: ${({ $hasBack }) => ($hasBack ? "16px" : "20px")};
 


### PR DESCRIPTION
## Summary
- `MobileHeaderWrapper` / `MainHeaderWrapper` 상단 패딩 중복 계산(`20px/16px + env(safe-area-inset-top)`) 정리로 헤더 영역 과다 여백 제거
- `MobileBottomNav` dimensions.width 미측정 시 fallback(`validWidth`/`validHeight`)으로 `activeX` 및 SVG 좌표 이탈 방지