### PR TITLE
feat: RN 멀티 웹뷰 환경 zustand/query 상태 동기화 (BroadcastChannel)

### DIFF
--- a/src/components/mobile/timetable/MobileCourseSearchSheet.tsx
+++ b/src/components/mobile/timetable/MobileCourseSearchSheet.tsx
@@ -281,7 +281,6 @@ const MobileCourseSearchSheet = ({
         onClose={() => onOpenChange(false)}
         snapPoints={SHEET_SNAP_POINTS}
         initialSnap={initialSnap}
-        disableDismiss
         disableScrollLocking
         onSnap={(snapIndex) => {
           const nextSnap = COURSE_SEARCH_SNAP_POINTS[snapIndex - 1];
@@ -455,6 +454,7 @@ const MobileCourseSearchSheet = ({
             </SheetContentWrapper>
           </CourseSheetScrollableContent>
         </CourseSheetContainer>
+        <Sheet.Backdrop onTap={() => onOpenChange(false)} />
       </CourseSheet>
 
       {open &&

--- a/src/components/mobile/timetable/TimeTableCreateModal.tsx
+++ b/src/components/mobile/timetable/TimeTableCreateModal.tsx
@@ -6,6 +6,7 @@ import { Timetable, useTimetableStore } from "@/stores/useTimetableStore";
 import { useSemesters } from "@/hooks/useSemesters";
 import { useCreateTimeTable } from "@/hooks/useTimeTables";
 import { formatSemester } from "@/utils/semester";
+import type { TimeTable } from "@/types/timetables";
 
 export const getDefaultTimetableName = (
   semester: string,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { initMixpanel } from "./utils/mixpanel";
 import "@/utils/bridgeChannel"; // 신 앱 PlatformChannel 초기화 + Native→Web 수신 결선
 import "@/styles/variables.css";
+import { attachQueryBroadcastSync } from "@/utils/queryBroadcastSync";
 
 initMixpanel();
 
@@ -19,6 +20,10 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+// RN 멀티 웹뷰 환경에서 같은 오리진의 다른 웹뷰(또는 브라우저 탭)와 쿼리
+// 캐시를 동기화한다. 자세한 배경은 src/utils/queryBroadcastSync.ts 참고.
+attachQueryBroadcastSync(queryClient);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <>

--- a/src/pages/mobile/timetable/MobileTimetableWizardPage.tsx
+++ b/src/pages/mobile/timetable/MobileTimetableWizardPage.tsx
@@ -251,7 +251,7 @@ export default function MobileTimetableWizardPage() {
         : {
             ...prev,
             // 새로 담을 때는 필수로 시작 - 이후 칩에서 "선택"으로 바꿀 수 있음
-            wishlist: [...prev.wishlist, { subjectNumber, required: true }],
+            wishlist: [...prev.wishlist, { subjectNumber, required: false }],
           },
     );
     setMustHaveSheetOpen(false);
@@ -399,12 +399,12 @@ export default function MobileTimetableWizardPage() {
 
           <Card>
             <CardLabelRow>
-              <CardLabel>꼭 넣고 싶은 강의</CardLabel>
+              <CardLabel>듣고 싶은 강의</CardLabel>
               <CardLabelCount>
                 {wishlistCourses.length} / {MAX_MUST_HAVE}
               </CardLabelCount>
             </CardLabelRow>
-            <CardHint>칩을 눌러 필수/선택을 바꿀 수 있어요. 선택은 안 맞으면 자동으로 빠져요.</CardHint>
+            <CardHint>강의 후보를 선택할 수 있어요. 필수로 포함돼야 할 강의는 "필수" 체크해주세요.</CardHint>
             {wishlistCourses.length > 0 && (
               <ChipRow>
                 {wishlistCourses.map((c) => (

--- a/src/stores/middleware/broadcastSync.ts
+++ b/src/stores/middleware/broadcastSync.ts
@@ -1,0 +1,38 @@
+import type { StateCreator, StoreApi } from "zustand";
+import { openMultiWebViewChannel } from "@/utils/multiWebViewChannel";
+
+interface BroadcastSyncOptions<T> {
+  /** 채널 이름. 스토어별로 고유해야 한다. */
+  name: string;
+  /** 다른 웹뷰로 전송할 직렬화 가능한 필드만 선택한다(액션 함수는 제외해야 함). */
+  partialize: (state: T) => Partial<T>;
+  /** 원격 업데이트를 반영한 직후 실행할 부수 효과(예: localStorage 갱신). */
+  onReceive?: (partial: Partial<T>, state: T) => void;
+}
+
+/**
+ * 같은 오리진의 다른 브라우징 컨텍스트(RN 멀티 웹뷰 환경의 다른 화면, 또는
+ * 브라우저의 다른 탭)와 zustand 스토어 상태를 동기화하는 미들웨어. 전송은
+ * BroadcastChannel + 네이티브 브릿지 릴레이 이중 경로(openMultiWebViewChannel
+ * 참고)를 쓰지만, 둘 다 발신 채널 자기 자신에게는 돌아오지 않으므로, 이 스토어의
+ * 액션이 쓰는 set(브로드캐스트 발신용)과 원격 메시지를 반영하는
+ * api.setState(브로드캐스트 미발신)를 분리하는 것만으로 재전송 루프가 생기지
+ * 않는다.
+ */
+export function broadcastSync<T extends object>(options: BroadcastSyncOptions<T>) {
+  return (creator: StateCreator<T, [], []>): StateCreator<T, [], []> =>
+    (set, get, api: StoreApi<T>) => {
+      const channel = openMultiWebViewChannel(options.name, (data) => {
+        const partial = data as Partial<T>;
+        api.setState(partial);
+        options.onReceive?.(partial, get());
+      });
+
+      const broadcastingSet: typeof set = (...args) => {
+        set(...args);
+        channel.postMessage(options.partialize(get()));
+      };
+
+      return creator(broadcastingSet, get, api);
+    };
+}

--- a/src/stores/useTimetableStore.ts
+++ b/src/stores/useTimetableStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { ClassItem } from "@/components/mobile/timetable/TimetableGrid";
 import type { TimeTable, TimeTableVisibility } from "@/types/timetables";
 import { formatSemester } from "@/utils/semester";
+import { broadcastSync } from "@/stores/middleware/broadcastSync";
 
 export interface TimetableTheme {
   colorTheme: "default" | "pastelWarm" | "pastelCool" | "monotone";
@@ -34,7 +35,18 @@ interface TimetableStore {
   updateTimetableEvents: (id: number, events: ClassItem[]) => void;
 }
 
-export const useTimetableStore = create<TimetableStore>((set) => ({
+export const useTimetableStore = create<TimetableStore>()(
+  broadcastSync<TimetableStore>({
+    // 시간표 상세 화면 등이 별도 웹뷰로 뜬 RN 멀티 웹뷰 환경에서, 거기서 편집한
+    // 시간표(요소 추가/테마 변경 등)가 이전 화면(다른 웹뷰)의 목록에도 즉시
+    // 반영되도록 동기화한다.
+    name: "timetable-store-sync",
+    partialize: (state) => ({
+      selectedSemester: state.selectedSemester,
+      activeTimetableId: state.activeTimetableId,
+      timetables: state.timetables,
+    }),
+  })((set) => ({
   selectedSemester: "",
   activeTimetableId: null,
   timetables: [],
@@ -92,4 +104,5 @@ export const useTimetableStore = create<TimetableStore>((set) => ({
         t.id === id ? { ...t, events } : t
       ),
     })),
-}));
+  })),
+);

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -83,4 +83,13 @@ const useUserStore = create<UserState>()(
   })),
 );
 
+// 네이티브가 자체 리프레시(백그라운드 FCM 토큰 등록 등)한 JWT를 store/localStorage에 반영.
+// (bridgeChannel.ts가 아닌 여기서 결선: bridgeChannel.ts → useUserStore.ts 순환 참조를
+// 피해야 broadcastSync가 store 생성 시점에 bridgeChannel을 참조해도 TDZ 에러가 나지 않는다.)
+if (bridgeChannel) {
+  bridgeChannel.on("tokenInfoUpdated", (tokenInfo) => {
+    useUserStore.getState().setTokenInfo(tokenInfo, { fromNative: true });
+  });
+}
+
 export default useUserStore;

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -3,6 +3,7 @@ import { normalizeUserInfo } from "@/utils/userInfo";
 import { create } from "zustand";
 import { identifyUser } from "@/utils/mixpanel";
 import { bridgeChannel } from "@/utils/bridgeChannel";
+import { broadcastSync } from "@/stores/middleware/broadcastSync";
 
 interface UserState {
   tokenInfo: TokenInfo;
@@ -34,38 +35,52 @@ const getInitialToken = () => {
   };
 };
 
-const useUserStore = create<UserState>((set) => ({
-  tokenInfo: getInitialToken(),
-  userInfo: normalizeUserInfo(),
-  isLoading: false, // 초기화 완료됨
+const useUserStore = create<UserState>()(
+  broadcastSync<UserState>({
+    // RN 멀티 웹뷰 환경에서 로그인 화면이 별도 WebView(네이티브 스택 push)로
+    // 뜨는 경우, 그 웹뷰에서 로그인해도 이전 화면의 useUserStore는 in-memory
+    // 상태라 갱신되지 않는다(새로고침/앱 재시작해야만 localStorage를 다시 읽어
+    // 살아남). 이 채널로 tokenInfo/userInfo 변경을 다른 웹뷰에도 즉시 반영한다.
+    name: "user-store-sync",
+    partialize: (state) => ({ tokenInfo: state.tokenInfo, userInfo: state.userInfo }),
+    onReceive: (partial) => {
+      if (partial.tokenInfo) {
+        localStorage.setItem("tokenInfo", JSON.stringify(partial.tokenInfo));
+      }
+    },
+  })((set) => ({
+    tokenInfo: getInitialToken(),
+    userInfo: normalizeUserInfo(),
+    isLoading: false, // 초기화 완료됨
 
-  setTokenInfo: (tokenInfo, options) => {
-    set(() => ({ tokenInfo }));
-    localStorage.setItem("tokenInfo", JSON.stringify(tokenInfo));
+    setTokenInfo: (tokenInfo, options) => {
+      set(() => ({ tokenInfo }));
+      localStorage.setItem("tokenInfo", JSON.stringify(tokenInfo));
 
-    // 네이티브 셸(intip-mobile-app)로 JWT를 미러링해 SecureStore에 보관시킨다 —
-    // 백그라운드 FCM 토큰 등록 등 네이티브가 웹뷰 없이 자체적으로 API를 호출해야
-    // 하는 시점의 인증에 쓰인다. fromNative=true(네이티브가 자체 리프레시한 값을
-    // echo-back으로 적용하는 경우)면 재전송을 생략해 무한 루프 없이 최대 1회
-    // echo에서 자연 종료된다.
-    if (bridgeChannel && !options?.fromNative) {
-      bridgeChannel.send("syncTokenInfo", tokenInfo);
-    }
-  },
-  setUserInfo: (userInfo) => {
-    const normalized = normalizeUserInfo(userInfo);
-    set(() => ({ userInfo: normalized }));
+      // 네이티브 셸(intip-mobile-app)로 JWT를 미러링해 SecureStore에 보관시킨다 —
+      // 백그라운드 FCM 토큰 등록 등 네이티브가 웹뷰 없이 자체적으로 API를 호출해야
+      // 하는 시점의 인증에 쓰인다. fromNative=true(네이티브가 자체 리프레시한 값을
+      // echo-back으로 적용하는 경우)면 재전송을 생략해 무한 루프 없이 최대 1회
+      // echo에서 자연 종료된다.
+      if (bridgeChannel && !options?.fromNative) {
+        bridgeChannel.send("syncTokenInfo", tokenInfo);
+      }
+    },
+    setUserInfo: (userInfo) => {
+      const normalized = normalizeUserInfo(userInfo);
+      set(() => ({ userInfo: normalized }));
 
-    // Mixpanel 사용자 식별
-    if (normalized.id) {
-      identifyUser(String(normalized.id), {
-        nickname: normalized.nickname,
-        department: normalized.department,
-        memberId: normalized.id,
-        role: normalized.role,
-      });
-    }
-  },
-}));
+      // Mixpanel 사용자 식별
+      if (normalized.id) {
+        identifyUser(String(normalized.id), {
+          nickname: normalized.nickname,
+          department: normalized.department,
+          memberId: normalized.id,
+          role: normalized.role,
+        });
+      }
+    },
+  })),
+);
 
 export default useUserStore;

--- a/src/types/friends.ts
+++ b/src/types/friends.ts
@@ -18,3 +18,32 @@ export interface FriendResponseDto {
   fireId: number;
   friendAlias?: string;
 }
+
+/**
+ * 주변 친구 찾기 - 위치 노출 on/off 요청 DTO
+ * (inu-appcenter/inu-portal-server#302, PATCH /api/members/nearby-visibility)
+ */
+export interface NearbyVisibilityRequestDto {
+  enabled: boolean;
+}
+
+/**
+ * 주변 친구 찾기 - 내 위치 갱신 요청 DTO
+ * (inu-appcenter/inu-portal-server#302, PUT /api/members/location)
+ */
+export interface MemberLocationRequestDto {
+  latitude: number;
+  longitude: number;
+}
+
+/**
+ * 주변 친구 찾기 - 반경 내 후보 응답 DTO
+ * (inu-appcenter/inu-portal-server#302, GET /api/friends/nearby)
+ */
+export interface NearbyMemberResponseDto {
+  memberId: number;
+  nickname: string;
+  studentId: string;
+  fireId: number;
+  distanceMeters: number;
+}

--- a/src/utils/bridgeChannel.ts
+++ b/src/utils/bridgeChannel.ts
@@ -1,7 +1,6 @@
 // 공유 브릿지는 packages/intip-bridge git 서브모듈로 두고 소스를 직접 컴파일한다
 // (npm 패키지/레지스트리 없음). CLAUDE.md 참고.
 import { createWebChannel, type WebChannel } from "../../packages/intip-bridge/src/adapters/web";
-import useUserStore from "@/stores/useUserStore";
 
 /**
  * 신 Expo 셸(intip-mobile-app)과의 단일 PlatformChannel.
@@ -29,10 +28,5 @@ if (bridgeChannel) {
     if (!path || window.location.pathname === path) return;
     window.history.pushState({}, "", path);
     window.dispatchEvent(new PopStateEvent("popstate"));
-  });
-
-  // 네이티브가 자체 리프레시(백그라운드 FCM 토큰 등록 등)한 JWT를 store/localStorage에 반영.
-  bridgeChannel.on("tokenInfoUpdated", (tokenInfo) => {
-    useUserStore.getState().setTokenInfo(tokenInfo, { fromNative: true });
   });
 }

--- a/src/utils/broadcastChannel.ts
+++ b/src/utils/broadcastChannel.ts
@@ -1,0 +1,18 @@
+/**
+ * BroadcastChannel 미지원 환경(구형 WebView 등)에서도 안전하게 no-op(null)로
+ * 동작하도록 감싼 팩토리. 채널 하나당 정확히 하나의 인스턴스를 만들어 쓰는
+ * 소유자(zustand 미들웨어, QueryClient 동기화 등)를 위한 것으로, 별도의
+ * 참조 카운팅 없이 소유자가 직접 생명주기를 관리한다.
+ */
+export function createSafeBroadcastChannel(name: string): BroadcastChannel | null {
+  if (typeof window === "undefined" || !("BroadcastChannel" in window)) {
+    return null;
+  }
+
+  try {
+    return new BroadcastChannel(name);
+  } catch (error) {
+    console.warn(`[broadcastChannel] BroadcastChannel(${name}) 생성 실패`, error);
+    return null;
+  }
+}

--- a/src/utils/multiWebViewChannel.ts
+++ b/src/utils/multiWebViewChannel.ts
@@ -1,0 +1,48 @@
+import { bridgeChannel } from "@/utils/bridgeChannel";
+import { createSafeBroadcastChannel } from "@/utils/broadcastChannel";
+
+export interface MultiWebViewChannel {
+  postMessage: (data: unknown) => void;
+  close: () => void;
+}
+
+/**
+ * 같은 오리진의 다른 웹뷰/탭에 상태 스냅샷을 전달하는 통합 채널.
+ *
+ * 두 경로를 동시에 쓴다:
+ *  1) BroadcastChannel API — 지원 환경에서 지연 없이 도달한다.
+ *  2) 네이티브 브릿지 릴레이(relayBroadcastSync → broadcastSyncMessage,
+ *     packages/intip-bridge) — BroadcastChannel 전역 자체가 없는 iOS 15.4
+ *     미만 WKWebView, 그리고 지원 버전에서도 WebKit의 웹뷰 인스턴스 간 전달이
+ *     알려진 대로 불안정한 경우를 위한 폴백. RN 셸 밖(일반 브라우저)에서는
+ *     `bridgeChannel`이 null이라 이 경로는 자동으로 빠진다.
+ *
+ * 페이로드는 매번 전체 스냅샷이라 두 경로로 중복 도착해도 멱등하게 반영되므로
+ * (수신측이 최신 값으로 그대로 덮어씀) 별도 dedup 없이 안전하다. 두 경로 모두
+ * 발신 채널 자기 자신에게는 되돌아오지 않는다(BroadcastChannel 스펙, 네이티브
+ * 릴레이는 발신 웹뷰를 제외하고 중계).
+ */
+export function openMultiWebViewChannel(
+  name: string,
+  onMessage: (data: unknown) => void,
+): MultiWebViewChannel {
+  const broadcastChannel = createSafeBroadcastChannel(name);
+  if (broadcastChannel) {
+    broadcastChannel.onmessage = (event: MessageEvent) => onMessage(event.data);
+  }
+
+  const offBridge = bridgeChannel?.on("broadcastSyncMessage", (message) => {
+    if (message.channel === name) onMessage(message.payload);
+  });
+
+  return {
+    postMessage: (data) => {
+      broadcastChannel?.postMessage(data);
+      bridgeChannel?.send("relayBroadcastSync", { channel: name, payload: data });
+    },
+    close: () => {
+      broadcastChannel?.close();
+      offBridge?.();
+    },
+  };
+}

--- a/src/utils/queryBroadcastSync.ts
+++ b/src/utils/queryBroadcastSync.ts
@@ -1,0 +1,68 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import { openMultiWebViewChannel } from "@/utils/multiWebViewChannel";
+
+type QueryBroadcastMessage =
+  | { type: "updated"; queryKey: QueryKey; data: unknown; dataUpdatedAt: number }
+  | { type: "removed"; queryKey: QueryKey };
+
+/**
+ * 같은 오리진의 다른 웹뷰/탭과 TanStack Query 캐시를 동기화한다(전송은
+ * openMultiWebViewChannel의 BroadcastChannel + 네이티브 브릿지 릴레이 이중
+ * 경로). 한 웹뷰에서 성공적으로 패치된 쿼리 데이터를 다른 웹뷰에도 즉시
+ * 반영해, 화면 전환 시(무한 스크롤 리스트로 돌아오는 경우 등) 불필요한
+ * 리패치 없이도 최신 상태를 보여준다. 실험적인 @tanstack/query-broadcast-client
+ * 대신, 필요한 "성공 데이터 반영/제거"만 직접 구현한다.
+ */
+export function attachQueryBroadcastSync(
+  queryClient: QueryClient,
+  name = "query-cache-sync",
+): () => void {
+  // 원격 메시지를 캐시에 반영하는 동안에는 그 반영으로 발생하는 'updated'
+  // 이벤트를 다시 내보내지 않도록 막아 핑퐁 루프를 방지한다.
+  let applyingRemote = false;
+
+  const channel = openMultiWebViewChannel(name, (data) => {
+    const message = data as QueryBroadcastMessage;
+    applyingRemote = true;
+    try {
+      if (message.type === "updated") {
+        const current = queryClient.getQueryState(message.queryKey);
+        if (current && current.dataUpdatedAt >= message.dataUpdatedAt) return;
+        queryClient.setQueryData(message.queryKey, message.data, {
+          updatedAt: message.dataUpdatedAt,
+        });
+      } else {
+        queryClient.removeQueries({ queryKey: message.queryKey, exact: true });
+      }
+    } finally {
+      applyingRemote = false;
+    }
+  });
+
+  const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+    if (applyingRemote) return;
+
+    if (event.type === "updated" && event.action.type === "success") {
+      if (event.query.state.data === undefined) return;
+      channel.postMessage({
+        type: "updated",
+        queryKey: event.query.queryKey,
+        data: event.query.state.data,
+        dataUpdatedAt: event.query.state.dataUpdatedAt,
+      } satisfies QueryBroadcastMessage);
+      return;
+    }
+
+    if (event.type === "removed") {
+      channel.postMessage({
+        type: "removed",
+        queryKey: event.query.queryKey,
+      } satisfies QueryBroadcastMessage);
+    }
+  });
+
+  return () => {
+    unsubscribe();
+    channel.close();
+  };
+}


### PR DESCRIPTION
## Summary
- 로그인 화면처럼 비메인탭 경로가 네이티브 스택에 별도 WebView로 push되는 멀티 웹뷰 환경에서, 로그인 후 이전 화면(다른 WebView)의 `useUserStore`가 in-memory 상태라 갱신되지 않아 "로그인이 안 돼있음"으로 보이던 문제를 해결합니다.
- `broadcastSync` zustand 미들웨어를 `useUserStore`(tokenInfo/userInfo), `useTimetableStore`(시간표 CRUD)에 적용했습니다.
- TanStack QueryCache도 `attachQueryBroadcastSync`로 동기화해, 성공적으로 fetch된 쿼리 데이터를 다른 웹뷰에 즉시 반영합니다(화면 전환 시 불필요한 리패치 방지).
- 전송은 BroadcastChannel + 네이티브 브릿지 릴레이(`intip-bridge`의 `relayBroadcastSync`/`broadcastSyncMessage`) 이중 경로입니다. iOS 15.4 미만 WKWebView는 BroadcastChannel 전역이 아예 없고, 지원 버전에서도 웹뷰 인스턴스 간 전달이 불안정하다는 사례가 있어 네이티브 릴레이를 폴백 겸 이중 경로로 둡니다.
- `packages/intip-bridge` 핀을 `relayBroadcastSync`/`broadcastSyncMessage` 메시지가 추가된 커밋(`5b440a7`)으로 갱신했습니다. 짝이 되는 `intip-mobile-app` 쪽 변경은 별도 PR로 올립니다.

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` (`tsc && vite build`) 통과
- [ ] 실기기/시뮬레이터에서: 홈에서 로그인 진입(새 WebView push) → 로그인 성공 → 뒤로가기 → 이전 화면(root WebView)에 로그인 상태가 즉시 반영되는지 확인
- [ ] 시간표 상세를 별도 웹뷰로 열어 편집 후 뒤로가기 시 목록 화면에 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvfMU9RgGrQHfHFB7ZW1nU