### PR TITLE
feat: 그룹 기반 시간표 마법사 플로우 추가 (에브리타임식)

### DIFF
--- a/src/components/mobile/timetable/wizard/group/GroupWizardCourseSearchSheet.tsx
+++ b/src/components/mobile/timetable/wizard/group/GroupWizardCourseSearchSheet.tsx
@@ -1,0 +1,1111 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode, UIEventHandler } from "react";
+import { createPortal } from "react-dom";
+import styled from "styled-components";
+import { Sheet, SheetRef } from "react-modal-sheet";
+import { useTransform } from "motion/react";
+import {
+  Check,
+  ChevronLeft,
+  FileText,
+  MessagesSquare,
+  Plus,
+  RotateCcw,
+  SearchX,
+  SlidersHorizontal,
+  X,
+} from "lucide-react";
+import Skeleton from "@/components/common/Skeleton";
+import CapsuleButton from "@/components/common/CapsuleButton";
+import FloatingSearchBar, {
+  FloatingSearchBarRef,
+} from "@/components/mobile/common/FloatingSearchBar";
+import CourseFilterPanel, {
+  resetTimeFilter,
+} from "@/components/mobile/timetable/filter/CourseFilterPanel";
+import {
+  FILTER_SUB_VIEW_TITLES,
+  countActiveFilters,
+} from "@/components/mobile/timetable/filter/courseFilterModel";
+import { mapFilterToOfferingFilters } from "@/utils/courseSearchResult";
+import { toWizardCourseOption } from "@/utils/timetableWizardPool";
+import { DAY_INDEX } from "@/utils/timetable";
+import { useCourses } from "@/hooks/useCourses";
+import { useCourseOfferings } from "@/hooks/useCourseOfferings";
+import useUserStore from "@/stores/useUserStore";
+import {
+  GROUP_WIZARD_SEARCH_SNAP_POINTS,
+  useTimetableGroupWizardStore,
+} from "@/stores/useTimetableGroupWizardStore";
+import type { CourseOffering } from "@/types/courseOfferings";
+import type { Course } from "@/types/courses";
+import type { WizardCourseOption } from "@/types/timetableWizard";
+
+/**
+ * 그룹 마법사의 강의 선택 바텀시트.
+ *
+ * 겉모습·상태 소유 규칙은 기존 WizardCourseSearchSheet와 동일하다(상태를 소유하지 않고
+ * useTimetableGroupWizardStore와 react-query에서 계산만 한다). 유일한 차이는 target이
+ * "어느 그룹에 담는지"까지 담은 판별 유니온이라, 담기 버튼이 그룹/제외 중 어디로 넣을지
+ * 명확하다는 점이다.
+ */
+
+const SHEET_CONTAINER_RATIO = 0.9;
+const SHEET_SNAP_POINTS = [
+  0,
+  ...GROUP_WIZARD_SEARCH_SNAP_POINTS.map((ratio) => ratio / SHEET_CONTAINER_RATIO),
+];
+
+const DAY_LABELS = ["월", "화", "수", "목", "금", "토", "일"];
+
+const SYLLABUS_UNAVAILABLE_MESSAGE =
+  "현 시점에는 제공되지 않아요. 원동력을 위해 학우 여러분의 많은 관심과 성원을 부탁드립니다!";
+const LECTURE_REVIEW_NOTICE_KEY = "lectureReviewEverytimeNoticeShown";
+const LECTURE_REVIEW_NOTICE_MESSAGE =
+  "현 시점에는 에브리타임 강의평 페이지로 이동해요. 다음학기부터 강의평 서비스가 제공될 예정이에요.";
+
+const openLectureReview = (professor: string) => {
+  const professorName = professor?.trim() || "";
+  if (!professorName) {
+    alert("교수명 정보가 없어 강의평을 바로 찾을 수 없어요.");
+    return;
+  }
+
+  if (!localStorage.getItem(LECTURE_REVIEW_NOTICE_KEY)) {
+    alert(LECTURE_REVIEW_NOTICE_MESSAGE);
+    localStorage.setItem(LECTURE_REVIEW_NOTICE_KEY, "true");
+  }
+
+  const url = `https://everytime.kr/lecture/search?keyword=${encodeURIComponent(professorName)}&condition=professor`;
+  window.open(url, "_blank", "noopener,noreferrer");
+};
+
+interface CourseRow {
+  offeringId: number;
+  subjectNumber: string;
+  title: string;
+  professor: string;
+  credit: number;
+  gradeLabel: string;
+  isMajor: boolean;
+  timeStr: string;
+  room: string;
+  enrolledCount: number | null;
+  capacity: number | null;
+  note: string | null;
+  option: WizardCourseOption;
+}
+
+const buildCourseRow = (
+  offering: CourseOffering,
+  course: Course | undefined,
+): CourseRow | null => {
+  const option = toWizardCourseOption(offering, course);
+  if (!option) return null;
+
+  const gradeName = offering.hyName ?? course?.targetGradeName ?? "";
+  const grade = parseInt(gradeName, 10);
+  const isuName = offering.isuName ?? course?.completionDivisionName ?? "";
+
+  return {
+    offeringId: offering.id,
+    subjectNumber: offering.subjectNumber,
+    title: option.title,
+    professor: offering.professor ?? "-",
+    credit: option.credit,
+    gradeLabel: Number.isFinite(grade) && grade > 0 ? `${grade}학년` : "전학년",
+    isMajor: isuName.includes("전공"),
+    timeStr: offering.meetings
+      .map((m) => `${DAY_LABELS[DAY_INDEX[m.day]]} ${m.startTime}~${m.endTime}`)
+      .join(", "),
+    room: offering.meetings[0]?.location ?? "-",
+    enrolledCount: offering.enrolledCount,
+    capacity: offering.capacity,
+    note: offering.note,
+    option,
+  };
+};
+
+interface ScrollableContentProps {
+  children: ReactNode;
+  onScrollCapture: UIEventHandler<HTMLDivElement>;
+  isAnimating: boolean;
+}
+
+const CourseSheetScrollableContent = ({
+  children,
+  onScrollCapture,
+  isAnimating,
+}: ScrollableContentProps) => {
+  const { y } = Sheet.useContext();
+  const scrollPaddingBottom = useTransform(y, (currentY) => currentY + 124);
+
+  return (
+    <CourseSheetContent
+      onScrollCapture={onScrollCapture}
+      scrollStyle={{ paddingBottom: scrollPaddingBottom }}
+      disableDrag={({ scrollPosition }) =>
+        scrollPosition !== undefined && scrollPosition !== "top"
+      }
+      disableScroll={({ currentSnap }) => isAnimating || currentSnap === 1}
+    >
+      {children}
+    </CourseSheetContent>
+  );
+};
+
+const GroupWizardCourseSearchSheet = () => {
+  const target = useTimetableGroupWizardStore((s) => s.search.target);
+  const snapIndex = useTimetableGroupWizardStore((s) => s.search.snapIndex);
+  const expandedOfferingId = useTimetableGroupWizardStore(
+    (s) => s.search.expandedOfferingId,
+  );
+  const keyword = useTimetableGroupWizardStore((s) => s.search.keyword);
+  const filters = useTimetableGroupWizardStore((s) => s.search.filters);
+  const filterDraft = useTimetableGroupWizardStore((s) => s.search.filterDraft);
+  const semester = useTimetableGroupWizardStore((s) => s.semester);
+  const groups = useTimetableGroupWizardStore((s) => s.groups);
+  const excludedCourses = useTimetableGroupWizardStore(
+    (s) => s.exclusion.excludedCourses,
+  );
+
+  const closeCourseSearch = useTimetableGroupWizardStore((s) => s.closeCourseSearch);
+  const setSearchSnapIndex = useTimetableGroupWizardStore((s) => s.setSearchSnapIndex);
+  const toggleExpandedOffering = useTimetableGroupWizardStore(
+    (s) => s.toggleExpandedOffering,
+  );
+  const setSearchKeyword = useTimetableGroupWizardStore((s) => s.setSearchKeyword);
+  const openFilterOverlay = useTimetableGroupWizardStore((s) => s.openFilterOverlay);
+  const updateFilterDraft = useTimetableGroupWizardStore((s) => s.updateFilterDraft);
+  const resetFilterDraft = useTimetableGroupWizardStore((s) => s.resetFilterDraft);
+  const applyFilterDraft = useTimetableGroupWizardStore((s) => s.applyFilterDraft);
+  const closeTopLayer = useTimetableGroupWizardStore((s) => s.closeTopLayer);
+  const addCourseToGroup = useTimetableGroupWizardStore((s) => s.addCourseToGroup);
+  const addExcludedCourse = useTimetableGroupWizardStore((s) => s.addExcludedCourse);
+
+  const userDepartment = useUserStore((state) => state.userInfo.department);
+
+  const isOpen = target !== null;
+
+  // 그룹 담기 시트일 때 대상 그룹의 표시 번호(1-base)와 현재 담긴 분반 목록
+  const targetGroup = useMemo(
+    () =>
+      target?.kind === "group"
+        ? groups.find((g) => g.id === target.groupId) ?? null
+        : null,
+    [target, groups],
+  );
+  const targetGroupNumber = useMemo(
+    () =>
+      target?.kind === "group"
+        ? groups.findIndex((g) => g.id === target.groupId) + 1
+        : 0,
+    [target, groups],
+  );
+
+  const sheetTitle =
+    target?.kind === "exclusion"
+      ? "빼고 싶은 강의 선택"
+      : targetGroupNumber > 0
+        ? `그룹 ${targetGroupNumber} 강의 담기`
+        : "강의 담기";
+
+  const [isAnimating, setIsAnimating] = useState(false);
+  const [isSearchActive, setIsSearchActive] = useState(false);
+  const searchBarRef = useRef<FloatingSearchBarRef>(null);
+
+  const offeringFilters = useMemo(
+    () => ({
+      ...mapFilterToOfferingFilters(filters),
+      keyword: keyword.trim() || undefined,
+    }),
+    [filters, keyword],
+  );
+
+  const { courses } = useCourses();
+  const courseById = useMemo(() => new Map(courses.map((c) => [c.id, c])), [courses]);
+
+  const {
+    courseOfferings,
+    isLoading,
+    isError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useCourseOfferings(semester?.year, semester?.term, offeringFilters, {
+    enabled: isOpen,
+  });
+
+  const rows = useMemo(() => {
+    const list = courseOfferings
+      .map((offering) => buildCourseRow(offering, courseById.get(offering.courseId)))
+      .filter((row): row is CourseRow => row !== null);
+
+    if (filters.sort === "담은인원많은순") {
+      return [...list].sort((a, b) => (b.enrolledCount ?? 0) - (a.enrolledCount ?? 0));
+    }
+    return list;
+  }, [courseOfferings, courseById, filters.sort]);
+
+  // 이미 담은 강의 표시: 그룹 담기는 그 그룹의 분반, 제외는 제외 목록 기준
+  const pickedSubjectNumbers = useMemo(
+    () =>
+      new Set(
+        target?.kind === "exclusion"
+          ? excludedCourses.map((c) => c.subjectNumber)
+          : (targetGroup?.options ?? []).map((o) => o.subjectNumber),
+      ),
+    [target, targetGroup, excludedCourses],
+  );
+
+  const activeFilterCount = useMemo(() => countActiveFilters(filters), [filters]);
+
+  const sheetRef = useRef<SheetRef | null>(null);
+  const reportedSnapIndexRef = useRef(snapIndex);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (snapIndex === reportedSnapIndexRef.current) return;
+    reportedSnapIndexRef.current = snapIndex;
+    sheetRef.current?.snapTo(snapIndex + 1);
+  }, [snapIndex, isOpen]);
+
+  useEffect(() => {
+    if (isSearchActive) return;
+    const timer = window.setTimeout(() => {
+      window.dispatchEvent(new Event("resize"));
+      window.scrollTo(0, window.scrollY);
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [isSearchActive]);
+
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  // 옵저버 콜백이 항상 최신 페이징 상태를 읽도록 ref에 담아두되, 갱신은 렌더가 아니라
+  // 이펙트에서 한다(react-hooks/refs: 렌더 중 ref.current 수정 금지).
+  const fetchMoreRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    fetchMoreRef.current = () => {
+      if (hasNextPage && !isFetchingNextPage && !isLoading) fetchNextPage();
+    };
+  }, [hasNextPage, isFetchingNextPage, isLoading, fetchNextPage]);
+
+  const loadMoreRef = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    if (!node) return;
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) fetchMoreRef.current();
+      },
+      { threshold: 0.1 },
+    );
+    observerRef.current.observe(node);
+  }, []);
+
+  useEffect(() => () => observerRef.current?.disconnect(), []);
+
+  const handleScroll: UIEventHandler<HTMLDivElement> = () => {
+    searchBarRef.current?.blur();
+  };
+
+  const handlePick = (row: CourseRow) => {
+    if (target?.kind === "exclusion") addExcludedCourse(row.option);
+    else if (target?.kind === "group") addCourseToGroup(target.groupId, row.option);
+    // 시트는 계속 열어둔다 - 한 번 열어 여러 과목을 담는 게 정상 흐름이다.
+  };
+
+  const draftFilterCount = filterDraft ? countActiveFilters(filterDraft.filters) : 0;
+
+  return (
+    <>
+      <CourseSheet
+        ref={sheetRef}
+        isOpen={isOpen}
+        onClose={closeCourseSearch}
+        snapPoints={SHEET_SNAP_POINTS}
+        initialSnap={snapIndex + 1}
+        disableScrollLocking
+        onSnap={(index) => {
+          if (index < 1) return;
+          reportedSnapIndexRef.current = index - 1;
+          setSearchSnapIndex(index - 1);
+        }}
+      >
+        <CourseSheetContainer
+          onAnimationStart={() => setIsAnimating(true)}
+          onAnimationComplete={() => setIsAnimating(false)}
+        >
+          <CourseSheetHeader />
+
+          <TitleBar>
+            <SheetTitle>{sheetTitle}</SheetTitle>
+            <CloseButton type="button" onClick={closeCourseSearch} aria-label="닫기">
+              <X size={18} />
+            </CloseButton>
+          </TitleBar>
+
+          <CourseSheetScrollableContent
+            onScrollCapture={handleScroll}
+            isAnimating={isAnimating}
+          >
+            <SheetContentWrapper>
+              <CourseList>
+                {isError ? (
+                  <EmptyContainer>
+                    <EmptyTitle>강의를 불러오지 못했어요</EmptyTitle>
+                    <EmptyDescription>
+                      잠시 후 다시 시도하거나 필터 조건을 바꿔 보세요
+                    </EmptyDescription>
+                  </EmptyContainer>
+                ) : isLoading ? (
+                  Array.from({ length: 6 }).map((_, index) => (
+                    <SkeletonCard key={`course-skeleton-${index}`}>
+                      <div className="skeleton-row-top">
+                        <Skeleton width="45%" height="20px" />
+                        <Skeleton
+                          width="70px"
+                          height="20px"
+                          style={{ borderRadius: "999px" }}
+                        />
+                      </div>
+                      <div className="skeleton-row-mid">
+                        <Skeleton width="50px" height="16px" />
+                        <Skeleton width="40px" height="16px" />
+                        <Skeleton width="50px" height="16px" />
+                      </div>
+                      <div className="skeleton-row-bottom">
+                        <Skeleton width="30%" height="14px" />
+                        <Skeleton width="50%" height="14px" />
+                      </div>
+                    </SkeletonCard>
+                  ))
+                ) : rows.length === 0 ? (
+                  <EmptyContainer>
+                    <SearchIconBox>
+                      <SearchX size={32} color="var(--gray-400, #b0b8c1)" />
+                    </SearchIconBox>
+                    <EmptyTitle>조회된 강의가 없습니다</EmptyTitle>
+                    <EmptyDescription>검색어나 필터 조건을 변경해 보세요</EmptyDescription>
+                  </EmptyContainer>
+                ) : (
+                  rows.map((row) => {
+                    const isExpanded = expandedOfferingId === row.offeringId;
+                    const isPicked = pickedSubjectNumbers.has(row.subjectNumber);
+
+                    return (
+                      <CourseItem
+                        key={row.offeringId}
+                        onClick={() => toggleExpandedOffering(row.offeringId)}
+                      >
+                        <InfoRow>
+                          <MainInfo>
+                            <CourseName>{row.title}</CourseName>
+                          </MainInfo>
+                          <RightInfo>
+                            {row.enrolledCount != null && row.capacity != null && (
+                              <EnrolledBadge>
+                                {row.enrolledCount}명 / {row.capacity}명
+                              </EnrolledBadge>
+                            )}
+                          </RightInfo>
+                        </InfoRow>
+
+                        <CourseAttributes>
+                          <AttributeItem $primary>{row.professor}</AttributeItem>
+                          <AttributeItem>{row.credit}학점</AttributeItem>
+                          <AttributeItem>상대평가</AttributeItem>
+                        </CourseAttributes>
+
+                        <CourseAdditionalInfo>
+                          <InfoLine>
+                            <span>{row.gradeLabel}</span>
+                            <span>{row.isMajor ? "전공심화" : "교양"}</span>
+                            <span>{row.subjectNumber}</span>
+                          </InfoLine>
+                          <div>{row.timeStr}</div>
+                          <div>{row.room}</div>
+                        </CourseAdditionalInfo>
+
+                        {isExpanded && (
+                          <ExpandedArea>
+                            {row.note && <RemarkText>비고 : {row.note}</RemarkText>}
+                            <ButtonRow>
+                              <PrimaryActionButton
+                                disabled={isPicked}
+                                $isAdded={isPicked}
+                                $exclusion={target?.kind === "exclusion"}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  if (!isPicked) handlePick(row);
+                                }}
+                              >
+                                {isPicked ? <Check size={20} /> : <Plus size={20} />}
+                                {isPicked
+                                  ? "담음"
+                                  : target?.kind === "exclusion"
+                                    ? "제외 목록에 추가"
+                                    : "이 그룹에 담기"}
+                              </PrimaryActionButton>
+                              <SecondaryActionButton
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  openLectureReview(row.professor);
+                                }}
+                              >
+                                <MessagesSquare size={20} />
+                                강의평
+                              </SecondaryActionButton>
+                              <SecondaryActionButton
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  alert(SYLLABUS_UNAVAILABLE_MESSAGE);
+                                }}
+                              >
+                                <FileText size={20} />
+                                강의계획서
+                              </SecondaryActionButton>
+                            </ButtonRow>
+                          </ExpandedArea>
+                        )}
+                      </CourseItem>
+                    );
+                  })
+                )}
+
+                {isFetchingNextPage && (
+                  <SkeletonCard key="next-page-skeleton">
+                    <div className="skeleton-row-top">
+                      <Skeleton width="45%" height="20px" />
+                      <Skeleton
+                        width="70px"
+                        height="20px"
+                        style={{ borderRadius: "999px" }}
+                      />
+                    </div>
+                    <div className="skeleton-row-mid">
+                      <Skeleton width="50px" height="16px" />
+                      <Skeleton width="40px" height="16px" />
+                      <Skeleton width="50px" height="16px" />
+                    </div>
+                  </SkeletonCard>
+                )}
+                {hasNextPage && !isLoading && (
+                  <div ref={loadMoreRef} style={{ height: "20px", width: "100%" }} />
+                )}
+              </CourseList>
+            </SheetContentWrapper>
+          </CourseSheetScrollableContent>
+
+          {filterDraft && (
+            <FilterOverlay>
+              <OverlayHeader>
+                <OverlayBackButton
+                  type="button"
+                  onClick={() => closeTopLayer()}
+                  aria-label="뒤로"
+                >
+                  <ChevronLeft size={22} />
+                </OverlayBackButton>
+                <OverlayTitle>{FILTER_SUB_VIEW_TITLES[filterDraft.view]}</OverlayTitle>
+                <OverlayHeaderSpacer />
+              </OverlayHeader>
+
+              <CourseFilterPanel
+                filters={filterDraft.filters}
+                onFiltersChange={(next) => updateFilterDraft({ filters: next })}
+                view={filterDraft.view}
+                onViewChange={(view) =>
+                  updateFilterDraft({ view, majorLevel1: null, majorLevel2: null })
+                }
+                majorLevel1={filterDraft.majorLevel1}
+                majorLevel2={filterDraft.majorLevel2}
+                onMajorLevelChange={(majorLevel1, majorLevel2) =>
+                  updateFilterDraft({ majorLevel1, majorLevel2 })
+                }
+                userDepartment={userDepartment}
+              />
+
+              <OverlayActions>
+                {filterDraft.view === "main" ? (
+                  <>
+                    <ResetButton
+                      variant="secondary"
+                      leftIcon={<RotateCcw size={16} />}
+                      onClick={resetFilterDraft}
+                    >
+                      초기화
+                    </ResetButton>
+                    <ApplyButton variant="primary" onClick={applyFilterDraft}>
+                      {draftFilterCount > 0
+                        ? `필터 ${draftFilterCount}개 적용`
+                        : "적용하기"}
+                    </ApplyButton>
+                  </>
+                ) : filterDraft.view === "time" ? (
+                  <>
+                    <ResetButton
+                      variant="secondary"
+                      leftIcon={<RotateCcw size={16} />}
+                      onClick={() =>
+                        updateFilterDraft({
+                          filters: resetTimeFilter(filterDraft.filters),
+                        })
+                      }
+                    >
+                      초기화
+                    </ResetButton>
+                    <ApplyButton
+                      variant="primary"
+                      onClick={() => updateFilterDraft({ view: "main" })}
+                    >
+                      선택 완료
+                    </ApplyButton>
+                  </>
+                ) : (
+                  <ApplyButton
+                    variant="primary"
+                    onClick={() => updateFilterDraft({ view: "main" })}
+                  >
+                    선택 완료
+                  </ApplyButton>
+                )}
+              </OverlayActions>
+            </FilterOverlay>
+          )}
+        </CourseSheetContainer>
+      </CourseSheet>
+
+      {isOpen &&
+        !filterDraft &&
+        createPortal(
+          <FloatingActionsContainer>
+            <FilterButton
+              $isHidden={isSearchActive}
+              $isZeroCount={activeFilterCount === 0}
+              onClick={openFilterOverlay}
+            >
+              <SlidersHorizontal size={20} />
+              {activeFilterCount > 0 && <span>필터 {activeFilterCount}</span>}
+            </FilterButton>
+
+            <FloatingSearchBar
+              key={
+                target
+                  ? target.kind === "group"
+                    ? target.groupId
+                    : "exclusion"
+                  : "closed"
+              }
+              ref={searchBarRef}
+              placeholder="교과목명, 교수명 검색"
+              onSearch={setSearchKeyword}
+              onActiveChange={setIsSearchActive}
+            />
+          </FloatingActionsContainer>,
+          document.body,
+        )}
+    </>
+  );
+};
+
+export default GroupWizardCourseSearchSheet;
+
+// --- styled-components (기존 WizardCourseSearchSheet와 동일한 시각 규격) ---
+
+const CourseSheet = styled(Sheet)`
+  z-index: 10000;
+`;
+
+const CourseSheetContainer = styled(Sheet.Container)`
+  left: 0;
+  right: 0;
+  width: min(100%, 768px);
+  height: 90dvh !important;
+  max-height: 90dvh !important;
+  margin: 0 auto;
+  overflow: hidden;
+  border-top: 1px solid var(--border-default, #e5e8eb);
+  border-top-left-radius: 32px !important;
+  border-top-right-radius: 32px !important;
+  border-bottom-right-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+  background: var(--bg-base, #ffffff);
+  box-shadow: 0 4px 24px 0 rgba(0, 0, 0, 0.25) !important;
+`;
+
+const CourseSheetHeader = styled(Sheet.Header)`
+  flex: 0 0 20px;
+
+  .react-modal-sheet-header {
+    height: 20px !important;
+    padding: 16px 0;
+    box-sizing: border-box;
+  }
+
+  .react-modal-sheet-drag-indicator-container {
+    width: 40px !important;
+    height: 4px !important;
+    border-radius: 2px !important;
+    background: var(--border-default, #e5e8eb) !important;
+  }
+
+  .react-modal-sheet-drag-indicator {
+    display: none !important;
+  }
+`;
+
+const TitleBar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex: 0 0 auto;
+  padding: 2px 20px 10px;
+`;
+
+const SheetTitle = styled.h2`
+  margin: 0;
+  color: var(--gray-900, #191f28);
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 24px;
+`;
+
+const CloseButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  border: none;
+  border-radius: 999px;
+  background: var(--bg-neutral-subtle, #f2f4f6);
+  color: var(--text-tertiary, #8b95a1);
+  cursor: pointer;
+  padding: 0;
+`;
+
+const CourseSheetContent = styled(Sheet.Content)`
+  min-height: 0;
+
+  .react-modal-sheet-content-scroller {
+    overscroll-behavior-y: none;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+`;
+
+const SheetContentWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  width: 100%;
+  padding: 0 20px;
+  box-sizing: border-box;
+`;
+
+const FloatingActionsContainer = styled.div`
+  position: fixed;
+  bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 40px);
+  max-width: calc(768px - 40px);
+  z-index: 10005;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  pointer-events: none;
+  box-sizing: border-box;
+`;
+
+const FilterButton = styled.button<{
+  $isHidden: boolean;
+  $isZeroCount?: boolean;
+}>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 48px;
+  border-radius: 999px;
+  cursor: pointer;
+  pointer-events: auto;
+  box-sizing: border-box;
+  white-space: nowrap;
+
+  border: ${({ $isZeroCount }) =>
+    $isZeroCount
+      ? "1px solid var(--border-default, #E5E8EB)"
+      : "1px solid var(--border-brand, #0061ff)"};
+  background: ${({ $isZeroCount }) =>
+    $isZeroCount ? "rgba(255, 255, 255, 0.50)" : "var(--interactive-primary, #3b82f6)"};
+  box-shadow: ${({ $isZeroCount }) =>
+    $isZeroCount
+      ? "0 4px 12px 0 rgba(0, 0, 0, 0.08)"
+      : "0 4px 12px rgba(59, 130, 246, 0.3)"};
+  backdrop-filter: ${({ $isZeroCount }) => ($isZeroCount ? "blur(8px)" : "none")};
+
+  color: ${({ $isZeroCount }) =>
+    $isZeroCount ? "var(--text-secondary, #333d4b)" : "var(--text-inverse, #fff)"};
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 20px;
+
+  width: fit-content;
+
+  transition:
+    max-width 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    padding 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    margin-right 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: max-width, padding, margin-right, opacity, transform;
+
+  ${(props) =>
+    props.$isHidden
+      ? `
+    max-width: 0px;
+    padding: 0;
+    margin-right: 0px;
+    opacity: 0;
+    pointer-events: none;
+    transform: scale(0.8);
+    border: 0px solid transparent;
+  `
+      : props.$isZeroCount
+        ? `
+    max-width: 48px;
+    padding: 12px;
+    margin-right: 12px;
+    opacity: 1;
+    pointer-events: auto;
+    transform: scale(1);
+  `
+        : `
+    max-width: 200px;
+    padding: 12px 16px;
+    margin-right: 12px;
+    opacity: 1;
+    pointer-events: auto;
+    transform: scale(1);
+  `}
+
+  &:active {
+    transform: scale(0.95);
+  }
+`;
+
+const CourseList = styled.div`
+  padding: 0;
+`;
+
+const EmptyContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 50px 20px;
+  text-align: center;
+`;
+
+const SearchIconBox = styled.div`
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: var(--bg-muted, #f1f3f5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 12px;
+`;
+
+const EmptyTitle = styled.h3`
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-secondary, #333d4b);
+  margin: 0 0 6px 0;
+`;
+
+const EmptyDescription = styled.p`
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--text-tertiary, #8b95a1);
+  margin: 0;
+`;
+
+const SkeletonCard = styled.div`
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-default, #e5e8eb);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  .skeleton-row-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .skeleton-row-mid {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+  }
+
+  .skeleton-row-bottom {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+`;
+
+const CourseItem = styled.div`
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-default, #e5e8eb);
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
+  transition: background-color 0.2s;
+
+  content-visibility: auto;
+  contain-intrinsic-size: auto 140px;
+`;
+
+const InfoRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const MainInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const CourseName = styled.h3`
+  color: var(--text-secondary, #333d4b);
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 24px;
+  margin: 0;
+`;
+
+const RightInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const EnrolledBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-brand-subtle, #d3e5ff);
+  background: var(--bg-brand-subtle, #eff6ff);
+  color: var(--text-brand, #0061ff);
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 16px;
+`;
+
+const CourseAttributes = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  align-items: center;
+`;
+
+const AttributeItem = styled.span<{ $primary?: boolean }>`
+  color: ${({ $primary }) =>
+    $primary ? "var(--text-secondary, #333d4b)" : "var(--text-tertiary, #8b95a1)"};
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 20px;
+`;
+
+const CourseAdditionalInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  color: var(--text-tertiary, #8b95a1);
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px;
+  margin-top: 4px;
+`;
+
+const InfoLine = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+const ExpandedArea = styled.div`
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  animation: fadeIn 0.2s ease-in-out;
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(-5px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+`;
+
+const RemarkText = styled.div`
+  color: var(--text-tertiary, #8b95a1);
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px;
+`;
+
+const ButtonRow = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+`;
+
+const ActionButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  transition: all 0.2s ease-in-out;
+  box-sizing: border-box;
+
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 20px;
+
+  &:active {
+    transform: scale(0.96);
+  }
+`;
+
+const PrimaryActionButton = styled(ActionButton)<{
+  $isAdded?: boolean;
+  $exclusion?: boolean;
+}>`
+  border-radius: 999px;
+  background: ${({ $exclusion }) =>
+    $exclusion ? "var(--text-error, #ef4444)" : "var(--interactive-primary, #3b82f6)"};
+  color: #fff;
+
+  ${({ $isAdded }) =>
+    $isAdded &&
+    `
+    background-color: var(--bg-neutral-subtle, #f2f4f6) !important;
+    color: var(--text-tertiary, #8b95a1) !important;
+    border: 1px solid var(--border-default, #e5e8eb);
+    cursor: not-allowed;
+    opacity: 0.8;
+  `}
+`;
+
+const SecondaryActionButton = styled(ActionButton)`
+  border: 1px solid var(--border-default, #e5e8eb);
+  background: var(--bg-subtle, #f8f9fb);
+  color: var(--text-primary, #333d4b);
+`;
+
+const FilterOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-subtle, #f8f9fb);
+  border-top-left-radius: 32px;
+  border-top-right-radius: 32px;
+  overflow: hidden;
+`;
+
+const OverlayHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 56px;
+  padding: 0 12px;
+  flex-shrink: 0;
+  background: var(--bg-base, #ffffff);
+  border-bottom: 1px solid var(--border-default, #e5e8eb);
+`;
+
+const OverlayBackButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary, #333d4b);
+  cursor: pointer;
+  flex-shrink: 0;
+`;
+
+const OverlayTitle = styled.span`
+  flex: 1;
+  text-align: center;
+  color: var(--gray-900, #191f28);
+  font-size: 17px;
+  font-weight: 600;
+`;
+
+const OverlayHeaderSpacer = styled.div`
+  width: 36px;
+  flex-shrink: 0;
+`;
+
+const OverlayActions = styled.div`
+  display: flex;
+  gap: 12px;
+  padding: 12px 20px calc(20px + env(safe-area-inset-bottom, 0px));
+  flex-shrink: 0;
+  background: var(--bg-base, #ffffff);
+  border-top: 1px solid var(--border-default, #e5e8eb);
+`;
+
+const ApplyButton = styled(CapsuleButton)`
+  flex: 1 1 0;
+  width: auto;
+  min-width: 0;
+  height: 52px;
+  min-height: 52px;
+`;
+
+const ResetButton = styled(ApplyButton)`
+  flex: 0 0 auto;
+  width: auto;
+  padding: 12px 16px;
+
+  span {
+    gap: 6px;
+    white-space: nowrap;
+  }
+`;

--- a/src/components/mobile/timetable/wizard/group/GroupWizardPreferenceStep.tsx
+++ b/src/components/mobile/timetable/wizard/group/GroupWizardPreferenceStep.tsx
@@ -1,0 +1,315 @@
+import styled from "styled-components";
+import type { WizardPreferenceConditions } from "@/types/timetableWizard";
+
+const DAY_LABELS = ["월", "화", "수", "목", "금"];
+
+interface GroupWizardPreferenceStepProps {
+  preference: WizardPreferenceConditions;
+  onChange: (
+    updater: (prev: WizardPreferenceConditions) => WizardPreferenceConditions,
+  ) => void;
+}
+
+/**
+ * 그룹 마법사의 선호조건(C-01~06) 스텝. UI/조건 코드는 기존 마법사 2단계와 동일하되,
+ * 스토어에 묶지 않고 (preference, onChange)만 받는 순수 표현 컴포넌트라 그룹 스토어에서
+ * 값을 흘려보내 쓴다. 기존 페이지의 인라인 구현은 건드리지 않는다.
+ */
+export default function GroupWizardPreferenceStep({
+  preference,
+  onChange,
+}: GroupWizardPreferenceStepProps) {
+  const toggleDay = (day: number) => {
+    onChange((prev) => {
+      const days = prev.freeDayOfWeek.days.includes(day)
+        ? prev.freeDayOfWeek.days.filter((d) => d !== day)
+        : [...prev.freeDayOfWeek.days, day];
+      return { ...prev, freeDayOfWeek: { ...prev.freeDayOfWeek, days } };
+    });
+  };
+
+  return (
+    <ScrollContent>
+      <SectionHeading>원하는 조건을 골라주세요 (중복 선택 가능)</SectionHeading>
+
+      <PreferenceCard
+        checked={preference.manyFreeDays}
+        onToggle={() => onChange((prev) => ({ ...prev, manyFreeDays: !prev.manyFreeDays }))}
+        title="공강 많은 시간표"
+        code="C-01"
+      />
+
+      <PreferenceCard
+        checked={preference.freeDayOfWeek.enabled}
+        onToggle={() =>
+          onChange((prev) => ({
+            ...prev,
+            freeDayOfWeek: {
+              ...prev.freeDayOfWeek,
+              enabled: !prev.freeDayOfWeek.enabled,
+            },
+          }))
+        }
+        title="특정 요일 공강"
+        code="C-02"
+      >
+        {preference.freeDayOfWeek.enabled && (
+          <DayRow>
+            {DAY_LABELS.map((label, index) => (
+              <DayButton
+                key={label}
+                type="button"
+                $active={preference.freeDayOfWeek.days.includes(index)}
+                onClick={() => toggleDay(index)}
+              >
+                {label}
+              </DayButton>
+            ))}
+          </DayRow>
+        )}
+      </PreferenceCard>
+
+      <PreferenceCard
+        checked={preference.noMorningClasses.enabled}
+        onToggle={() =>
+          onChange((prev) => ({
+            ...prev,
+            noMorningClasses: {
+              ...prev.noMorningClasses,
+              enabled: !prev.noMorningClasses.enabled,
+            },
+          }))
+        }
+        title="오전 수업 없는 시간표"
+        code="C-03"
+      >
+        {preference.noMorningClasses.enabled && (
+          <SelectBox
+            value={preference.noMorningClasses.startAfter}
+            onChange={(e) =>
+              onChange((prev) => ({
+                ...prev,
+                noMorningClasses: {
+                  ...prev.noMorningClasses,
+                  startAfter: Number(e.target.value),
+                },
+              }))
+            }
+          >
+            <option value={9.5}>9:30 이후 시작</option>
+            <option value={10}>10:00 이후 시작</option>
+            <option value={10.5}>10:30 이후 시작</option>
+            <option value={11}>11:00 이후 시작</option>
+            <option value={12}>12:00 이후 시작</option>
+          </SelectBox>
+        )}
+        {preference.noMorningClasses.enabled && (
+          <WarningInline>⚠ 선택한 조건으로는 시간표가 안 나올 수 있어요</WarningInline>
+        )}
+      </PreferenceCard>
+
+      <PreferenceCard
+        checked={preference.noNightClasses}
+        onToggle={() =>
+          onChange((prev) => ({ ...prev, noNightClasses: !prev.noNightClasses }))
+        }
+        title="야간 수업 제외"
+        code="C-04"
+      />
+
+      <PreferenceCard
+        checked={preference.fewConsecutive}
+        onToggle={() =>
+          onChange((prev) => ({ ...prev, fewConsecutive: !prev.fewConsecutive }))
+        }
+        title="연강 적은 시간표"
+        code="C-05"
+      />
+
+      <PreferenceCard
+        checked={preference.avoidCommute}
+        onToggle={() => onChange((prev) => ({ ...prev, avoidCommute: !prev.avoidCommute }))}
+        title="통학 시간 피하기"
+        code="C-06"
+      />
+
+      <BottomActionsSpacer />
+    </ScrollContent>
+  );
+}
+
+interface PreferenceCardProps {
+  checked: boolean;
+  onToggle: () => void;
+  title: string;
+  code: string;
+  children?: React.ReactNode;
+}
+
+function PreferenceCard({ checked, onToggle, title, code, children }: PreferenceCardProps) {
+  return (
+    <PreferenceCardBox $checked={checked}>
+      <PreferenceHead onClick={onToggle}>
+        <CheckboxInput type="checkbox" checked={checked} readOnly />
+        <PreferenceTextWrap>
+          <PreferenceTitle $checked={checked}>{title}</PreferenceTitle>
+          <PreferenceCode>{code}</PreferenceCode>
+        </PreferenceTextWrap>
+      </PreferenceHead>
+      {checked && children}
+    </PreferenceCardBox>
+  );
+}
+
+const ScrollContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  -webkit-overflow-scrolling: touch;
+`;
+
+const Card = styled.div`
+  background: var(--bg-base, #ffffff);
+  border: 1px solid var(--border-default, #e5e8eb);
+  border-radius: 20px;
+  padding: 18px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+  box-sizing: border-box;
+  flex-shrink: 0;
+`;
+
+const PreferenceCardBox = styled(Card)<{ $checked: boolean }>`
+  border-width: ${({ $checked }) => ($checked ? "1.5px" : "1px")};
+  border-color: ${({ $checked }) =>
+    $checked ? "var(--interactive-primary, #3b82f6)" : "var(--border-default, #e5e8eb)"};
+`;
+
+const WarningInline = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #fff8e9;
+  border: 1px solid #fdd9aa;
+  color: #d97706;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 18px;
+`;
+
+const SelectBox = styled.select`
+  width: 100%;
+  height: 52px;
+  padding: 0 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border-default, #e5e8eb);
+  background: var(--bg-subtle, #f8f9fb);
+  color: var(--text-primary, #191f28);
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 52px;
+  box-sizing: border-box;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'><path d='M1 1l5 5 5-5' stroke='%238B95A1' stroke-width='1.5' fill='none' fill-rule='evenodd'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
+`;
+
+const SectionHeading = styled.h2`
+  margin: 0 0 4px;
+  color: var(--text-tertiary, #8b95a1);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+`;
+
+const PreferenceHead = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+`;
+
+const PreferenceTextWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const PreferenceTitle = styled.span<{ $checked: boolean }>`
+  color: var(--text-primary, #191f28);
+  font-size: 15px;
+  font-weight: ${({ $checked }) => ($checked ? 700 : 500)};
+  line-height: 23px;
+`;
+
+const PreferenceCode = styled.span`
+  color: var(--text-tertiary, #8b95a1);
+  font-size: 11px;
+  line-height: 17px;
+`;
+
+const CheckboxInput = styled.input`
+  appearance: none;
+  -webkit-appearance: none;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  border-radius: 6px;
+  border: 1.5px solid var(--gray-400, #b0b8c1);
+  background-color: var(--bg-base, #ffffff);
+  position: relative;
+  cursor: pointer;
+  outline: none;
+  transition: all 0.2s;
+
+  &:checked {
+    border-color: var(--interactive-primary, #3b82f6);
+    background-color: var(--interactive-primary, #3b82f6);
+  }
+
+  &:checked::after {
+    content: "";
+    position: absolute;
+    left: 7px;
+    top: 3px;
+    width: 5px;
+    height: 10px;
+    border: solid #ffffff;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+  }
+`;
+
+const DayRow = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+const DayButton = styled.button<{ $active: boolean }>`
+  flex: 1;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid
+    ${({ $active }) =>
+      $active ? "var(--interactive-primary, #3b82f6)" : "var(--border-default, #e5e8eb)"};
+  background: ${({ $active }) =>
+    $active ? "var(--interactive-primary, #3b82f6)" : "var(--bg-subtle, #f8f9fb)"};
+  color: ${({ $active }) => ($active ? "#ffffff" : "var(--text-secondary, #333d4b)")};
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+`;
+
+const BottomActionsSpacer = styled.div`
+  height: 80px;
+  flex-shrink: 0;
+`;

--- a/src/components/mobile/timetable/wizard/group/GroupWizardStep3Exclusion.tsx
+++ b/src/components/mobile/timetable/wizard/group/GroupWizardStep3Exclusion.tsx
@@ -1,0 +1,196 @@
+import styled from "styled-components";
+import { Search, X } from "lucide-react";
+import TimetableGrid from "@/components/mobile/timetable/TimetableGrid";
+import { useTimetableGroupWizardStore } from "@/stores/useTimetableGroupWizardStore";
+
+const EMPTY_EVENTS: never[] = [];
+
+/**
+ * 그룹 마법사의 제외 조건 스텝. 기존 마법사 3단계와 동작·UI가 동일하고, 스토어만
+ * useTimetableGroupWizardStore를 바라본다. 제외 강의도 스냅샷으로 들고 있어 필터를 바꿔도
+ * 칩이 사라지지 않는다.
+ */
+const GroupWizardStep3Exclusion = () => {
+  const excludedSlots = useTimetableGroupWizardStore((s) => s.exclusion.excludedSlots);
+  const excludedCourses = useTimetableGroupWizardStore(
+    (s) => s.exclusion.excludedCourses,
+  );
+  const setExcludedSlots = useTimetableGroupWizardStore((s) => s.setExcludedSlots);
+  const removeExcludedCourse = useTimetableGroupWizardStore(
+    (s) => s.removeExcludedCourse,
+  );
+  const openCourseSearch = useTimetableGroupWizardStore((s) => s.openCourseSearch);
+  const semester = useTimetableGroupWizardStore((s) => s.semester);
+
+  const excludedSlotCount = new Set(excludedSlots).size;
+
+  return (
+    <ScrollContent>
+      <Card>
+        <CardHead>
+          <CardTitle>수업 넣고 싶지 않은 시간</CardTitle>
+          <CardSubtitle>드래그해서 선택하세요</CardSubtitle>
+        </CardHead>
+        <TimetableGrid
+          events={EMPTY_EVENTS}
+          isSelectionMode
+          minDayCount={7}
+          selectedSlots={excludedSlots}
+          onSelectedSlotsChange={setExcludedSlots}
+        />
+        <Legend>
+          <LegendSwatch />
+          제외한 시간대 ({excludedSlotCount}칸)
+        </Legend>
+      </Card>
+
+      <Card>
+        <CardTitle>빼고 싶은 강의</CardTitle>
+        <SearchFieldButton
+          type="button"
+          disabled={semester === null}
+          onClick={() => openCourseSearch({ kind: "exclusion" })}
+        >
+          <Search size={16} color="var(--text-tertiary, #8b95a1)" />
+          <span>교과목명, 교수명 검색</span>
+        </SearchFieldButton>
+        {excludedCourses.length > 0 && (
+          <ChipRow>
+            {excludedCourses.map((c) => (
+              <Chip key={c.subjectNumber}>
+                <span>{c.title}</span>
+                <ChipRemove onClick={() => removeExcludedCourse(c.subjectNumber)}>
+                  <X size={12} />
+                </ChipRemove>
+              </Chip>
+            ))}
+          </ChipRow>
+        )}
+      </Card>
+
+      <BottomActionsSpacer />
+    </ScrollContent>
+  );
+};
+
+export default GroupWizardStep3Exclusion;
+
+const ScrollContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  -webkit-overflow-scrolling: touch;
+`;
+
+const Card = styled.div`
+  background: var(--bg-base, #ffffff);
+  border: 1px solid var(--border-default, #e5e8eb);
+  border-radius: 20px;
+  padding: 18px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+  box-sizing: border-box;
+  flex-shrink: 0;
+`;
+
+const CardHead = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const CardTitle = styled.span`
+  color: var(--text-primary, #191f28);
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 23px;
+`;
+
+const CardSubtitle = styled.span`
+  color: var(--text-tertiary, #8b95a1);
+  font-size: 12px;
+  line-height: 18px;
+`;
+
+const Legend = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-tertiary, #8b95a1);
+  font-size: 13px;
+`;
+
+const LegendSwatch = styled.span`
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  background: rgba(0, 97, 255, 0.4);
+  flex-shrink: 0;
+`;
+
+const SearchFieldButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 48px;
+  padding: 0 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border-default, #e5e8eb);
+  background: var(--bg-subtle, #f8f9fb);
+  cursor: pointer;
+  text-align: left;
+
+  span {
+    color: var(--text-tertiary, #8b95a1);
+    font-size: 14px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const ChipRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const Chip = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 8px 8px 14px;
+  border-radius: 999px;
+  background: var(--bg-error, #fff0f0);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+
+  span {
+    color: var(--text-error, #ef4444);
+    font-size: 14px;
+    font-weight: 500;
+  }
+`;
+
+const ChipRemove = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: var(--text-error, #ef4444);
+  cursor: pointer;
+`;
+
+const BottomActionsSpacer = styled.div`
+  height: 80px;
+  flex-shrink: 0;
+`;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -26,6 +26,7 @@ export const ROUTES = {
     CALCULATOR: "/timetable/calculator",
     SYLLABUS: "/timetable/syllabus",
     WIZARD: "/timetable/wizard",
+    WIZARD_GROUP: "/timetable/wizard-group",
   },
 
   // 친구

--- a/src/pages/mobile/timetable/MobileTimetableGroupWizardPage.tsx
+++ b/src/pages/mobile/timetable/MobileTimetableGroupWizardPage.tsx
@@ -1,0 +1,664 @@
+import { useCallback, useEffect, useMemo } from "react";
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import { Plus, X } from "lucide-react";
+import { useHeader } from "@/context/HeaderContext";
+import CapsuleButton from "@/components/common/CapsuleButton";
+import Badge from "@/components/common/Badge";
+import { useSemesters } from "@/hooks/useSemesters";
+import useUserStore from "@/stores/useUserStore";
+import {
+  GROUP_WIZARD_MAX_CREDIT_SCALE,
+  GROUP_WIZARD_MIN_CREDIT_SCALE,
+  useTimetableGroupWizardStore,
+} from "@/stores/useTimetableGroupWizardStore";
+import { generateGroupWizardCandidates } from "@/utils/timetableGroupWizardGenerator";
+import CreditRangeSlider from "@/components/mobile/timetable/wizard/CreditRangeSlider";
+import WizardStepIndicator from "@/components/mobile/timetable/wizard/WizardStepIndicator";
+import WizardGeneratingScreen from "@/components/mobile/timetable/wizard/WizardGeneratingScreen";
+import WizardResultsScreen from "@/components/mobile/timetable/wizard/WizardResultsScreen";
+import WizardDetailScreen from "@/components/mobile/timetable/wizard/WizardDetailScreen";
+import WizardSaveFlow from "@/components/mobile/timetable/wizard/WizardSaveFlow";
+import {
+  WizardEmptyState,
+  WizardErrorState,
+} from "@/components/mobile/timetable/wizard/WizardEmptyErrorScreens";
+import GroupWizardCourseSearchSheet from "@/components/mobile/timetable/wizard/group/GroupWizardCourseSearchSheet";
+import GroupWizardPreferenceStep from "@/components/mobile/timetable/wizard/group/GroupWizardPreferenceStep";
+import GroupWizardStep3Exclusion from "@/components/mobile/timetable/wizard/group/GroupWizardStep3Exclusion";
+
+const GENERATING_MIN_VISIBLE_MS = 1600;
+
+const COMPACT_TERM_LABELS: Record<string, string> = {
+  FIRST: "1학기",
+  SECOND: "2학기",
+  SUMMER: "여름학기",
+  WINTER: "겨울학기",
+};
+const formatSemesterCompact = (year: number, term: string) =>
+  `${year}-${COMPACT_TERM_LABELS[term] ?? term}`;
+
+/**
+ * 에브리타임식 그룹 마법사 페이지.
+ *
+ * 기존 마법사(MobileTimetableWizardPage)와 스텝 구성(기본조건 → 선호 → 제외 → 생성 →
+ * 결과 → 상세 → 저장)은 같지만, "강의 선택과 최초 경우의 수 생성"만 다르다:
+ *  - 스텝1의 강의 선택이 위시리스트가 아니라 사용자가 만든 그룹들이다.
+ *  - 생성기가 각 그룹에서 하나씩 꺼내 카르테시안 곱으로 조합을 만든다.
+ * 그 외 선호·제외 스텝, 생성중/결과/상세/저장 화면은 기존 프레젠테이션 컴포넌트를 그대로
+ * 재사용한다(기존 파일은 수정하지 않는다).
+ */
+export default function MobileTimetableGroupWizardPage() {
+  const navigate = useNavigate();
+  const { semesters } = useSemesters();
+  const userDepartment = useUserStore((state) => state.userInfo.department);
+
+  const step = useTimetableGroupWizardStore((s) => s.step);
+  const semester = useTimetableGroupWizardStore((s) => s.semester);
+  const minCredit = useTimetableGroupWizardStore((s) => s.minCredit);
+  const maxCredit = useTimetableGroupWizardStore((s) => s.maxCredit);
+  const groups = useTimetableGroupWizardStore((s) => s.groups);
+  const preference = useTimetableGroupWizardStore((s) => s.preference);
+  const exclusion = useTimetableGroupWizardStore((s) => s.exclusion);
+  const result = useTimetableGroupWizardStore((s) => s.result);
+  const selectedCandidateId = useTimetableGroupWizardStore((s) => s.selectedCandidateId);
+  const isSaveSheetOpen = useTimetableGroupWizardStore((s) => s.isSaveSheetOpen);
+
+  const setStep = useTimetableGroupWizardStore((s) => s.setStep);
+  const setSemester = useTimetableGroupWizardStore((s) => s.setSemester);
+  const setCreditRange = useTimetableGroupWizardStore((s) => s.setCreditRange);
+  const addGroup = useTimetableGroupWizardStore((s) => s.addGroup);
+  const removeGroup = useTimetableGroupWizardStore((s) => s.removeGroup);
+  const removeCourseFromGroup = useTimetableGroupWizardStore(
+    (s) => s.removeCourseFromGroup,
+  );
+  const updatePreference = useTimetableGroupWizardStore((s) => s.updatePreference);
+  const setResult = useTimetableGroupWizardStore((s) => s.setResult);
+  const selectCandidate = useTimetableGroupWizardStore((s) => s.selectCandidate);
+  const openSaveSheet = useTimetableGroupWizardStore((s) => s.openSaveSheet);
+  const closeSaveSheet = useTimetableGroupWizardStore((s) => s.closeSaveSheet);
+  const openCourseSearch = useTimetableGroupWizardStore((s) => s.openCourseSearch);
+  const closeTopLayer = useTimetableGroupWizardStore((s) => s.closeTopLayer);
+  const seedDefaultMajor = useTimetableGroupWizardStore((s) => s.seedDefaultMajor);
+  const resetWizard = useTimetableGroupWizardStore((s) => s.resetWizard);
+
+  useEffect(() => {
+    seedDefaultMajor(userDepartment || "컴퓨터공학부");
+  }, [userDepartment, seedDefaultMajor]);
+
+  useEffect(() => {
+    if (semesters.length === 0) return;
+    if (semester && semesters.some((s) => s.id === semester.id)) return;
+    const preferred = semesters.find((s) => s.status === "OPEN") ?? semesters[0];
+    setSemester({ id: preferred.id, year: preferred.year, term: preferred.term });
+  }, [semesters, semester, setSemester]);
+
+  useEffect(() => {
+    if (step !== "generating") return;
+
+    let generated;
+    try {
+      generated = generateGroupWizardCandidates({
+        basic: { semester, minCredit, maxCredit, groups },
+        preference,
+        exclusion,
+      });
+    } catch (e) {
+      console.error("그룹 시간표 조합 생성 실패:", e);
+      setStep("error");
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setResult(generated);
+      setStep(generated.candidates.length === 0 ? "empty" : "results");
+    }, GENERATING_MIN_VISIBLE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    step,
+    semester,
+    minCredit,
+    maxCredit,
+    groups,
+    preference,
+    exclusion,
+    setResult,
+    setStep,
+  ]);
+
+  const runGeneration = useCallback(() => setStep("generating"), [setStep]);
+
+  const selectedCandidate = useMemo(
+    () => result?.candidates.find((c) => c.id === selectedCandidateId) ?? null,
+    [result, selectedCandidateId],
+  );
+
+  const handleBack = useCallback(() => {
+    if (closeTopLayer()) return;
+    switch (step) {
+      case "step1":
+        navigate(-1);
+        break;
+      case "step2":
+        setStep("step1");
+        break;
+      case "step3":
+        setStep("step2");
+        break;
+      case "detail":
+        setStep("results");
+        break;
+      default:
+        setStep("step3");
+    }
+  }, [closeTopLayer, step, navigate, setStep]);
+
+  const headerConfig = useMemo(() => {
+    switch (step) {
+      case "step1":
+        return { title: "그룹 강의 선택", rightArea: <StepBadge>1/3</StepBadge> };
+      case "step2":
+        return { title: "선호 조건", rightArea: <StepBadge>2/3</StepBadge> };
+      case "step3":
+        return { title: "제외 조건", rightArea: <StepBadge>3/3</StepBadge> };
+      case "generating":
+        return { visible: false };
+      case "results":
+        return {
+          title: "추천 시간표",
+          rightArea: (
+            <HeaderTextButton onClick={runGeneration}>다시 만들기</HeaderTextButton>
+          ),
+        };
+      case "detail":
+        return {
+          title: selectedCandidate?.label ?? "추천 시간표",
+          rightArea: selectedCandidate && (
+            <Badge
+              text={`${selectedCandidate.totalCredit}학점 · ${selectedCandidate.courses.length}과목`}
+            />
+          ),
+        };
+      default:
+        return { title: "추천 시간표" };
+    }
+  }, [step, runGeneration, selectedCandidate]);
+
+  useHeader({
+    hasback: true,
+    showAlarm: false,
+    pageBgColor: "var(--bg-subtle, #f8f9fb)",
+    rightAreaNotCircle: true,
+    onBack: handleBack,
+    ...headerConfig,
+  });
+
+  const isConditionStep = step === "step1" || step === "step2" || step === "step3";
+
+  const handlePrimaryNext = () => {
+    if (step === "step1") setStep("step2");
+    else if (step === "step2") setStep("step3");
+    else if (step === "step3") runGeneration();
+  };
+
+  const semesterLabel = semester
+    ? formatSemesterCompact(semester.year, semester.term)
+    : "학기를 선택하세요";
+
+  const totalPickedCount = groups.reduce((sum, g) => sum + g.options.length, 0);
+
+  return (
+    <PageWrapper>
+      {isConditionStep && (
+        <WizardStepIndicator step={step === "step1" ? 1 : step === "step2" ? 2 : 3} />
+      )}
+
+      {step === "step1" && (
+        <ScrollContent>
+          <Card>
+            <CardLabel>
+              학기<Required>*</Required>
+            </CardLabel>
+            <SelectBox
+              value={semester?.id ?? ""}
+              onChange={(e) => {
+                const found = semesters.find((s) => s.id === Number(e.target.value));
+                if (!found) return;
+                setSemester({ id: found.id, year: found.year, term: found.term });
+              }}
+            >
+              {semesters.length === 0 && <option value="">{semesterLabel}</option>}
+              {semesters.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {formatSemesterCompact(s.year, s.term)}
+                </option>
+              ))}
+            </SelectBox>
+          </Card>
+
+          <Card>
+            <CardLabelRow>
+              <CardLabel>목표 학점</CardLabel>
+              <CardLabelValue>
+                {minCredit} ~ {maxCredit}학점
+              </CardLabelValue>
+            </CardLabelRow>
+            <CreditRangeSlider
+              min={GROUP_WIZARD_MIN_CREDIT_SCALE}
+              max={GROUP_WIZARD_MAX_CREDIT_SCALE}
+              valueMin={minCredit}
+              valueMax={maxCredit}
+              onChange={({ min, max }) => setCreditRange(min, max)}
+            />
+          </Card>
+
+          <GroupsIntro>
+            <GroupsIntroTitle>그룹마다 듣고 싶은 강의를 1개 이상 담아주세요</GroupsIntroTitle>
+            <GroupsIntroText>
+              각 그룹에서 강의를 하나씩 꺼내 조합해 시간표를 만들어요. 시간은 무관하지만
+              "이 중 하나는 꼭 듣고 싶은" 강의들을 한 그룹에 담아두세요.
+            </GroupsIntroText>
+          </GroupsIntro>
+
+          {groups.map((group, index) => (
+            <GroupCard key={group.id}>
+              <GroupHead>
+                <GroupTitle>그룹 {index + 1}</GroupTitle>
+                <GroupCount>{group.options.length}개</GroupCount>
+                <GroupHeadSpacer />
+                <GroupRemoveButton
+                  type="button"
+                  aria-label={`그룹 ${index + 1} 삭제`}
+                  onClick={() => removeGroup(group.id)}
+                >
+                  <X size={16} />
+                </GroupRemoveButton>
+              </GroupHead>
+
+              {group.options.length > 0 && (
+                <ChipRow>
+                  {group.options.map((option) => (
+                    <Chip key={option.subjectNumber}>
+                      <ChipText>
+                        {option.title}
+                        {option.professor ? ` · ${option.professor}` : ""}
+                      </ChipText>
+                      <ChipRemove
+                        type="button"
+                        onClick={() =>
+                          removeCourseFromGroup(group.id, option.subjectNumber)
+                        }
+                      >
+                        <X size={12} />
+                      </ChipRemove>
+                    </Chip>
+                  ))}
+                </ChipRow>
+              )}
+
+              <AddCourseButton
+                type="button"
+                disabled={semester === null}
+                onClick={() => openCourseSearch({ kind: "group", groupId: group.id })}
+              >
+                <Plus size={18} />
+                강의 추가
+              </AddCourseButton>
+            </GroupCard>
+          ))}
+
+          <AddGroupButton type="button" onClick={addGroup}>
+            <Plus size={18} />
+            그룹 추가
+          </AddGroupButton>
+
+          <BottomActionsSpacer />
+        </ScrollContent>
+      )}
+
+      {step === "step2" && (
+        <GroupWizardPreferenceStep preference={preference} onChange={updatePreference} />
+      )}
+
+      {step === "step3" && <GroupWizardStep3Exclusion />}
+
+      {step === "generating" && (
+        <WizardGeneratingScreen onCancel={() => setStep("step3")} />
+      )}
+
+      {step === "results" && result && (
+        <WizardResultsScreen
+          candidates={result.candidates}
+          onSelectCandidate={(id) => {
+            selectCandidate(id);
+            setStep("detail");
+          }}
+        />
+      )}
+
+      {step === "detail" && selectedCandidate && (
+        <WizardDetailScreen candidate={selectedCandidate} />
+      )}
+
+      {step === "empty" && result && (
+        <WizardEmptyState conflicts={result.conflicts} onRelax={() => setStep("step1")} />
+      )}
+
+      {step === "error" && <WizardErrorState onRetry={runGeneration} />}
+
+      {isConditionStep && (
+        <FixedBottomContainer>
+          <BottomActionButton
+            variant="primary"
+            disabled={step === "step1" && semester === null}
+            onClick={handlePrimaryNext}
+          >
+            {step === "step1"
+              ? totalPickedCount > 0
+                ? "다음"
+                : "강의를 담고 다음"
+              : step === "step3"
+                ? "시간표 만들기"
+                : "다음"}
+          </BottomActionButton>
+        </FixedBottomContainer>
+      )}
+
+      {step === "detail" && selectedCandidate && (
+        <FixedBottomContainer>
+          <BottomActionButton variant="primary" onClick={openSaveSheet}>
+            이 시간표 저장
+          </BottomActionButton>
+        </FixedBottomContainer>
+      )}
+
+      <GroupWizardCourseSearchSheet />
+
+      {selectedCandidate && (
+        <WizardSaveFlow
+          open={isSaveSheetOpen}
+          onOpenChange={(open) => {
+            if (!open) closeSaveSheet();
+          }}
+          candidate={selectedCandidate}
+          semesterId={semester?.id ?? null}
+          onSaved={() => {
+            resetWizard();
+            navigate(-1);
+          }}
+        />
+      )}
+    </PageWrapper>
+  );
+}
+
+// --- styled-components ---------------------------------------------------
+
+const PageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - var(--header-height));
+  width: 100%;
+  box-sizing: border-box;
+  background-color: var(--bg-subtle, #f8f9fb);
+`;
+
+const ScrollContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  -webkit-overflow-scrolling: touch;
+`;
+
+const StepBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  color: var(--text-tertiary, #8b95a1);
+  font-size: 14px;
+  font-weight: 600;
+`;
+
+const HeaderTextButton = styled.button`
+  background: none;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  color: var(--text-brand, #0061ff);
+  font-size: 15px;
+  font-weight: 600;
+  padding: 8px 4px;
+  white-space: nowrap;
+`;
+
+const Card = styled.div`
+  background: var(--bg-base, #ffffff);
+  border: 1px solid var(--border-default, #e5e8eb);
+  border-radius: 20px;
+  padding: 18px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+  box-sizing: border-box;
+  flex-shrink: 0;
+`;
+
+const CardLabelRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const CardLabel = styled.span`
+  color: var(--text-secondary, #333d4b);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 23px;
+`;
+
+const CardLabelValue = styled.span`
+  color: var(--interactive-primary, #3b82f6);
+  font-size: 15px;
+  font-weight: 600;
+`;
+
+const Required = styled.span`
+  color: var(--interactive-primary, #3b82f6);
+  margin-left: 2px;
+`;
+
+const SelectBox = styled.select`
+  width: 100%;
+  height: 52px;
+  padding: 0 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border-default, #e5e8eb);
+  background: var(--bg-subtle, #f8f9fb);
+  color: var(--text-primary, #191f28);
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 52px;
+  box-sizing: border-box;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'><path d='M1 1l5 5 5-5' stroke='%238B95A1' stroke-width='1.5' fill='none' fill-rule='evenodd'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
+`;
+
+const GroupsIntro = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 2px 4px;
+`;
+
+const GroupsIntroTitle = styled.h2`
+  margin: 0;
+  color: var(--text-primary, #191f28);
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 22px;
+`;
+
+const GroupsIntroText = styled.p`
+  margin: 0;
+  color: var(--text-tertiary, #8b95a1);
+  font-size: 12px;
+  line-height: 18px;
+`;
+
+const GroupCard = styled(Card)`
+  gap: 12px;
+`;
+
+const GroupHead = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const GroupTitle = styled.span`
+  color: var(--text-primary, #191f28);
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 22px;
+`;
+
+const GroupCount = styled.span`
+  color: var(--text-tertiary, #8b95a1);
+  font-size: 13px;
+  font-weight: 400;
+`;
+
+const GroupHeadSpacer = styled.div`
+  flex: 1;
+`;
+
+const GroupRemoveButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border: none;
+  border-radius: 999px;
+  background: var(--bg-neutral-subtle, #f2f4f6);
+  color: var(--text-tertiary, #8b95a1);
+  cursor: pointer;
+  padding: 0;
+`;
+
+const ChipRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const Chip = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px 6px 12px;
+  border-radius: 999px;
+  background: var(--bg-brand, #eff6ff);
+  border: 1px solid transparent;
+  max-width: 100%;
+`;
+
+const ChipText = styled.span`
+  color: var(--interactive-primary, #3b82f6);
+  font-size: 14px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const ChipRemove = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: var(--interactive-primary, #3b82f6);
+  cursor: pointer;
+  flex-shrink: 0;
+`;
+
+const AddCourseButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 48px;
+  border-radius: 14px;
+  border: 1px dashed var(--interactive-primary, #3b82f6);
+  background: var(--bg-subtle, #f8f9fb);
+  color: var(--interactive-primary, #3b82f6);
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const AddGroupButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 52px;
+  border-radius: 16px;
+  border: 1px solid var(--border-default, #e5e8eb);
+  background: var(--bg-base, #ffffff);
+  color: var(--text-secondary, #333d4b);
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+`;
+
+const BottomActionsSpacer = styled.div`
+  height: 80px;
+  flex-shrink: 0;
+`;
+
+const FixedBottomContainer = styled.div`
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 768px;
+  background: transparent;
+  padding: 0 24px;
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  box-sizing: border-box;
+  z-index: 100;
+`;
+
+const BottomActionButton = styled(CapsuleButton)`
+  flex: 1 1 0;
+  width: auto;
+  min-width: 0;
+  height: 56px;
+  min-height: 56px;
+  padding: 12px 24px;
+`;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -60,6 +60,7 @@ import MobileCourseAddPage from "@/pages/mobile/timetable/MobileCourseAddPage";
 import MobileSugangSimulatorPage from "@/pages/mobile/timetable/MobileSugangSimulatorPage";
 import MobileCourseFilterPage from "@/pages/mobile/timetable/MobileCourseFilterPage";
 import MobileTimetableWizardPage from "@/pages/mobile/timetable/MobileTimetableWizardPage";
+import MobileTimetableGroupWizardPage from "@/pages/mobile/timetable/MobileTimetableGroupWizardPage";
 import MobileTimeTableListPage from "@/pages/mobile/timetable/MobileTimeTableListPage";
 import MobileGradeCalculatorPage from "@/pages/mobile/timetable/MobileGradeCalculatorPage";
 import MobileSyllabusPage from "@/pages/mobile/timetable/MobileSyllabusPage";
@@ -143,6 +144,10 @@ export const router = createBrowserRouter([
           { path: ROUTES.TIMETABLE.ADD, element: <MobileCourseAddPage /> },
           { path: ROUTES.TIMETABLE.FILTER, element: <MobileCourseFilterPage /> },
           { path: ROUTES.TIMETABLE.WIZARD, element: <MobileTimetableWizardPage /> },
+          {
+            path: ROUTES.TIMETABLE.WIZARD_GROUP,
+            element: <MobileTimetableGroupWizardPage />,
+          },
           { path: ROUTES.TIMETABLE.LIST, element: <MobileTimeTableListPage /> },
           { path: ROUTES.TIMETABLE.CALCULATOR, element: <MobileGradeCalculatorPage /> },
           { path: ROUTES.TIMETABLE.SYLLABUS, element: <MobileSyllabusPage /> },

--- a/src/stores/useTimetableGroupWizardStore.ts
+++ b/src/stores/useTimetableGroupWizardStore.ts
@@ -1,0 +1,489 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import {
+  DEFAULT_EXCLUSION_CONDITIONS,
+  DEFAULT_PREFERENCE_CONDITIONS,
+} from "@/types/timetableWizard";
+import type {
+  WizardCourseOption,
+  WizardExclusionConditions,
+  WizardGenerationResult,
+  WizardPreferenceConditions,
+  WizardSemesterSelection,
+  WizardStep,
+} from "@/types/timetableWizard";
+import type { WizardCourseGroup } from "@/types/timetableGroupWizard";
+import {
+  DEFAULT_FILTERS,
+  type FilterState,
+  type FilterSubView,
+} from "@/components/mobile/timetable/filter/courseFilterModel";
+
+/**
+ * 에브리타임식 "그룹 마법사"의 단일 상태 공급원.
+ *
+ * 기존 useTimetableWizardStore와 설계 규칙(사실 하나에 소유자 하나, 표현 불가능한 상태는
+ * 타입으로 차단, 시트는 명시적 액션으로만 열림)은 그대로 따르되, 강의 선택 모델만 다르다.
+ * 위시리스트(필수/선택 토글) 대신 사용자가 직접 만든 그룹 배열을 들고 있고, 강의 검색
+ * 시트는 "어느 그룹에 담는지"까지 target에 실어 표현 불가능한 상태를 차단한다.
+ *
+ * 기존 마법사 스토어와 완전히 분리되어 있어(별도 persist 키) 두 플로우가 서로의 상태를
+ * 덮어쓰지 않는다. 기존 파일은 전혀 수정하지 않는다.
+ */
+
+export const GROUP_WIZARD_SEARCH_SNAP_POINTS = [0.18, 0.45, 0.9] as const;
+export const GROUP_WIZARD_SEARCH_DEFAULT_SNAP_INDEX = 1;
+
+export const GROUP_WIZARD_MIN_CREDIT_SCALE = 12;
+export const GROUP_WIZARD_MAX_CREDIT_SCALE = 21;
+const DEFAULT_MIN_CREDIT = 15;
+const DEFAULT_MAX_CREDIT = 18;
+
+const DEFAULT_GROUP_COUNT = 2;
+
+let groupIdSeq = 0;
+const makeGroupId = () =>
+  `g_${Date.now().toString(36)}_${(groupIdSeq++).toString(36)}`;
+
+const createDefaultGroups = (): WizardCourseGroup[] =>
+  Array.from({ length: DEFAULT_GROUP_COUNT }, () => ({
+    id: makeGroupId(),
+    options: [],
+  }));
+
+/**
+ * 강의 검색 시트를 어떤 목적으로 열었는지. null이면 닫힌 상태다.
+ * 그룹에 담을 때는 어느 그룹인지까지 실어 "어느 그룹에 담는 시트인지 알 수 없는" 상태를 없앤다.
+ */
+export type GroupCourseSearchTarget =
+  | { kind: "group"; groupId: string }
+  | { kind: "exclusion" };
+
+/** 필터 오버레이가 편집 중인 초안. null이면 오버레이가 닫혀 있다. */
+export interface FilterDraft {
+  filters: FilterState;
+  view: FilterSubView;
+  majorLevel1: string | null;
+  majorLevel2: string | null;
+}
+
+interface CourseSearchState {
+  target: GroupCourseSearchTarget | null;
+  snapIndex: number;
+  expandedOfferingId: number | null;
+  keyword: string;
+  filters: FilterState;
+  filterDraft: FilterDraft | null;
+}
+
+interface GroupWizardState {
+  step: WizardStep;
+  semester: WizardSemesterSelection | null;
+  minCredit: number;
+  maxCredit: number;
+  groups: WizardCourseGroup[];
+  preference: WizardPreferenceConditions;
+  exclusion: WizardExclusionConditions;
+  result: WizardGenerationResult | null;
+  selectedCandidateId: string | null;
+  isSaveSheetOpen: boolean;
+  search: CourseSearchState;
+  didSeedDefaultMajor: boolean;
+}
+
+interface GroupWizardActions {
+  setStep: (step: WizardStep) => void;
+
+  setSemester: (semester: WizardSemesterSelection) => void;
+  setCreditRange: (min: number, max: number) => void;
+
+  // --- 그룹 (스텝 1) ---
+  addGroup: () => void;
+  removeGroup: (groupId: string) => void;
+  addCourseToGroup: (groupId: string, course: WizardCourseOption) => void;
+  removeCourseFromGroup: (groupId: string, subjectNumber: string) => void;
+
+  updatePreference: (
+    updater: (prev: WizardPreferenceConditions) => WizardPreferenceConditions,
+  ) => void;
+
+  setExcludedSlots: (slots: string[]) => void;
+  addExcludedCourse: (course: WizardCourseOption) => void;
+  removeExcludedCourse: (subjectNumber: string) => void;
+
+  setResult: (result: WizardGenerationResult) => void;
+  selectCandidate: (candidateId: string) => void;
+  openSaveSheet: () => void;
+  closeSaveSheet: () => void;
+
+  openCourseSearch: (target: GroupCourseSearchTarget) => void;
+  closeCourseSearch: () => void;
+  setSearchSnapIndex: (index: number) => void;
+  toggleExpandedOffering: (offeringId: number) => void;
+  setSearchKeyword: (keyword: string) => void;
+
+  openFilterOverlay: () => void;
+  updateFilterDraft: (patch: Partial<FilterDraft>) => void;
+  resetFilterDraft: () => void;
+  applyFilterDraft: () => void;
+  cancelFilterOverlay: () => void;
+
+  closeTopLayer: () => boolean;
+
+  seedDefaultMajor: (department: string) => void;
+  resetWizard: () => void;
+}
+
+export type TimetableGroupWizardStore = GroupWizardState & GroupWizardActions;
+
+const createInitialSearchState = (): CourseSearchState => ({
+  target: null,
+  snapIndex: GROUP_WIZARD_SEARCH_DEFAULT_SNAP_INDEX,
+  expandedOfferingId: null,
+  keyword: "",
+  filters: { ...DEFAULT_FILTERS },
+  filterDraft: null,
+});
+
+const createInitialState = (): GroupWizardState => ({
+  step: "step1",
+  semester: null,
+  minCredit: DEFAULT_MIN_CREDIT,
+  maxCredit: DEFAULT_MAX_CREDIT,
+  groups: createDefaultGroups(),
+  preference: { ...DEFAULT_PREFERENCE_CONDITIONS },
+  exclusion: { ...DEFAULT_EXCLUSION_CONDITIONS },
+  result: null,
+  selectedCandidateId: null,
+  isSaveSheetOpen: false,
+  search: createInitialSearchState(),
+  didSeedDefaultMajor: false,
+});
+
+const INVALIDATE_RESULT = {
+  result: null,
+  selectedCandidateId: null,
+  isSaveSheetOpen: false,
+} as const;
+
+const clampSnapIndex = (index: number) =>
+  Math.min(
+    Math.max(Math.trunc(index), 0),
+    GROUP_WIZARD_SEARCH_SNAP_POINTS.length - 1,
+  );
+
+const RESTORABLE_STEPS: WizardStep[] = ["step1", "step2", "step3"];
+
+export const useTimetableGroupWizardStore = create<TimetableGroupWizardStore>()(
+  persist(
+    (set, get) => ({
+      ...createInitialState(),
+
+      setStep: (step) => set({ step }),
+
+      setSemester: (semester) =>
+        set((state) =>
+          state.semester?.id === semester.id
+            ? state
+            : {
+                semester,
+                // 학기가 바뀌면 이전 학기 개설강의로 담은 그룹/제외 강의는 전부 무의미하다.
+                groups: createDefaultGroups(),
+                exclusion: { ...state.exclusion, excludedCourses: [] },
+                ...INVALIDATE_RESULT,
+              },
+        ),
+
+      setCreditRange: (min, max) =>
+        set({
+          minCredit: Math.max(GROUP_WIZARD_MIN_CREDIT_SCALE, Math.min(min, max)),
+          maxCredit: Math.min(GROUP_WIZARD_MAX_CREDIT_SCALE, Math.max(min, max)),
+          ...INVALIDATE_RESULT,
+        }),
+
+      addGroup: () =>
+        set((state) => ({
+          groups: [...state.groups, { id: makeGroupId(), options: [] }],
+          ...INVALIDATE_RESULT,
+        })),
+
+      removeGroup: (groupId) =>
+        set((state) => {
+          // 그룹은 최소 1개는 남긴다(마지막 그룹을 지우면 빈 그룹 하나로 되돌린다)
+          const remaining = state.groups.filter((g) => g.id !== groupId);
+          return {
+            groups:
+              remaining.length > 0 ? remaining : [{ id: makeGroupId(), options: [] }],
+            ...INVALIDATE_RESULT,
+          };
+        }),
+
+      addCourseToGroup: (groupId, course) =>
+        set((state) => {
+          const group = state.groups.find((g) => g.id === groupId);
+          if (!group) return state;
+          if (group.options.some((o) => o.subjectNumber === course.subjectNumber)) {
+            return state; // 같은 그룹에 이미 있는 분반은 중복으로 담지 않는다
+          }
+          return {
+            groups: state.groups.map((g) =>
+              g.id === groupId ? { ...g, options: [...g.options, course] } : g,
+            ),
+            ...INVALIDATE_RESULT,
+          };
+        }),
+
+      removeCourseFromGroup: (groupId, subjectNumber) =>
+        set((state) => ({
+          groups: state.groups.map((g) =>
+            g.id === groupId
+              ? {
+                  ...g,
+                  options: g.options.filter((o) => o.subjectNumber !== subjectNumber),
+                }
+              : g,
+          ),
+          ...INVALIDATE_RESULT,
+        })),
+
+      updatePreference: (updater) =>
+        set((state) => ({
+          preference: updater(state.preference),
+          ...INVALIDATE_RESULT,
+        })),
+
+      setExcludedSlots: (slots) =>
+        set((state) => ({
+          exclusion: { ...state.exclusion, excludedSlots: slots },
+          ...INVALIDATE_RESULT,
+        })),
+
+      addExcludedCourse: (course) =>
+        set((state) =>
+          state.exclusion.excludedCourses.some(
+            (c) => c.subjectNumber === course.subjectNumber,
+          )
+            ? state
+            : {
+                exclusion: {
+                  ...state.exclusion,
+                  excludedCourses: [...state.exclusion.excludedCourses, course],
+                },
+                ...INVALIDATE_RESULT,
+              },
+        ),
+
+      removeExcludedCourse: (subjectNumber) =>
+        set((state) => ({
+          exclusion: {
+            ...state.exclusion,
+            excludedCourses: state.exclusion.excludedCourses.filter(
+              (c) => c.subjectNumber !== subjectNumber,
+            ),
+          },
+          ...INVALIDATE_RESULT,
+        })),
+
+      setResult: (result) =>
+        set({ result, selectedCandidateId: null, isSaveSheetOpen: false }),
+
+      selectCandidate: (candidateId) => set({ selectedCandidateId: candidateId }),
+
+      openSaveSheet: () => set({ isSaveSheetOpen: true }),
+
+      closeSaveSheet: () => set({ isSaveSheetOpen: false }),
+
+      openCourseSearch: (target) =>
+        set((state) => ({
+          search: {
+            ...state.search,
+            target,
+            snapIndex: GROUP_WIZARD_SEARCH_DEFAULT_SNAP_INDEX,
+            expandedOfferingId: null,
+            keyword: "",
+            filterDraft: null,
+          },
+        })),
+
+      closeCourseSearch: () =>
+        set((state) => ({
+          search: {
+            ...state.search,
+            target: null,
+            expandedOfferingId: null,
+            keyword: "",
+            filterDraft: null,
+          },
+        })),
+
+      setSearchSnapIndex: (index) =>
+        set((state) => ({
+          search: { ...state.search, snapIndex: clampSnapIndex(index) },
+        })),
+
+      toggleExpandedOffering: (offeringId) =>
+        set((state) => ({
+          search: {
+            ...state.search,
+            expandedOfferingId:
+              state.search.expandedOfferingId === offeringId ? null : offeringId,
+          },
+        })),
+
+      setSearchKeyword: (keyword) =>
+        set((state) => ({ search: { ...state.search, keyword } })),
+
+      openFilterOverlay: () =>
+        set((state) => ({
+          search: {
+            ...state.search,
+            snapIndex: GROUP_WIZARD_SEARCH_SNAP_POINTS.length - 1,
+            filterDraft: {
+              filters: { ...state.search.filters },
+              view: "main",
+              majorLevel1: null,
+              majorLevel2: null,
+            },
+          },
+        })),
+
+      updateFilterDraft: (patch) =>
+        set((state) =>
+          state.search.filterDraft
+            ? {
+                search: {
+                  ...state.search,
+                  filterDraft: { ...state.search.filterDraft, ...patch },
+                },
+              }
+            : state,
+        ),
+
+      resetFilterDraft: () =>
+        set((state) =>
+          state.search.filterDraft
+            ? {
+                search: {
+                  ...state.search,
+                  filterDraft: {
+                    ...state.search.filterDraft,
+                    filters: { ...DEFAULT_FILTERS },
+                  },
+                },
+              }
+            : state,
+        ),
+
+      applyFilterDraft: () =>
+        set((state) =>
+          state.search.filterDraft
+            ? {
+                search: {
+                  ...state.search,
+                  filters: state.search.filterDraft.filters,
+                  filterDraft: null,
+                  expandedOfferingId: null,
+                },
+              }
+            : state,
+        ),
+
+      cancelFilterOverlay: () =>
+        set((state) => ({ search: { ...state.search, filterDraft: null } })),
+
+      closeTopLayer: () => {
+        const { search, isSaveSheetOpen } = get();
+        const draft = search.filterDraft;
+
+        if (draft) {
+          if (draft.view === "major" && draft.majorLevel2) {
+            get().updateFilterDraft({ majorLevel2: null });
+          } else if (draft.view === "major" && draft.majorLevel1) {
+            get().updateFilterDraft({ majorLevel1: null });
+          } else if (draft.view !== "main") {
+            get().updateFilterDraft({ view: "main" });
+          } else {
+            get().cancelFilterOverlay();
+          }
+          return true;
+        }
+
+        if (search.target) {
+          get().closeCourseSearch();
+          return true;
+        }
+
+        if (isSaveSheetOpen) {
+          get().closeSaveSheet();
+          return true;
+        }
+
+        return false;
+      },
+
+      seedDefaultMajor: (department) =>
+        set((state) => {
+          const major = department.trim();
+          if (state.didSeedDefaultMajor || !major) return state;
+          return {
+            didSeedDefaultMajor: true,
+            search: {
+              ...state.search,
+              filters: { ...state.search.filters, major },
+            },
+          };
+        }),
+
+      resetWizard: () =>
+        set((state) => ({
+          ...createInitialState(),
+          didSeedDefaultMajor: state.didSeedDefaultMajor,
+          search: {
+            ...createInitialSearchState(),
+            filters: state.search.filters,
+          },
+        })),
+    }),
+    {
+      name: "timetable-group-wizard",
+      version: 1,
+      partialize: (state) => ({
+        step: RESTORABLE_STEPS.includes(state.step) ? state.step : "step3",
+        semester: state.semester,
+        minCredit: state.minCredit,
+        maxCredit: state.maxCredit,
+        groups: state.groups,
+        preference: state.preference,
+        exclusion: state.exclusion,
+        didSeedDefaultMajor: state.didSeedDefaultMajor,
+        searchFilters: state.search.filters,
+      }),
+      merge: (persisted, current) => {
+        const saved = (persisted ?? {}) as Partial<GroupWizardState> & {
+          searchFilters?: FilterState;
+        };
+        return {
+          ...current,
+          ...saved,
+          // 저장된 그룹이 비었으면(구버전/손상) 기본 그룹으로 되돌린다
+          groups:
+            saved.groups && saved.groups.length > 0
+              ? saved.groups
+              : createDefaultGroups(),
+          step:
+            saved.step && RESTORABLE_STEPS.includes(saved.step) ? saved.step : "step1",
+
+          result: null,
+          selectedCandidateId: null,
+          isSaveSheetOpen: false,
+          search: {
+            ...createInitialSearchState(),
+            filters: saved.searchFilters
+              ? { ...DEFAULT_FILTERS, ...saved.searchFilters }
+              : { ...DEFAULT_FILTERS },
+          },
+        };
+      },
+    },
+  ),
+);

--- a/src/types/timetableGroupWizard.ts
+++ b/src/types/timetableGroupWizard.ts
@@ -1,0 +1,38 @@
+import type {
+  WizardCourseOption,
+  WizardExclusionConditions,
+  WizardPreferenceConditions,
+  WizardSemesterSelection,
+} from "@/types/timetableWizard";
+
+/**
+ * 에브리타임식 "그룹 마법사"의 강의 선택 단위.
+ *
+ * 기존 마법사(위시리스트+필수/선택 토글)와의 결정적 차이는 "그룹"을 사용자가 명시적으로
+ * 만든다는 점이다. 그룹 하나에는 "시간은 무관하지만 이 중 하나는 꼭 듣고 싶은" 강의들을
+ * 담고, 조합 생성기는 각 그룹에서 정확히 하나씩 꺼내 카르테시안 곱으로 경우의 수를 만든다.
+ *
+ * 기존 위시리스트가 courseId로 분반을 자동 그룹화했던 것과 달리, 여기서는 서로 다른
+ * 과목(예: 골프 / 필라테스)도 한 그룹에 넣어 "이 둘 중 하나"를 표현할 수 있다.
+ *
+ * options는 위시리스트와 같은 이유로 subjectNumber 참조가 아니라 강의 스냅샷을 통째로
+ * 들고 있다(조회 필터가 바뀌어도 담긴 강의가 사라지지 않는다).
+ */
+export interface WizardCourseGroup {
+  /** 로컬에서만 쓰는 안정적인 그룹 식별자 (표시 번호는 배열 인덱스로 파생) */
+  id: string;
+  options: WizardCourseOption[];
+}
+
+export interface WizardGroupBasicConditions {
+  semester: WizardSemesterSelection | null;
+  minCredit: number;
+  maxCredit: number;
+  groups: WizardCourseGroup[];
+}
+
+export interface WizardGroupConditions {
+  basic: WizardGroupBasicConditions;
+  preference: WizardPreferenceConditions;
+  exclusion: WizardExclusionConditions;
+}

--- a/src/utils/timetableGroupWizardGenerator.ts
+++ b/src/utils/timetableGroupWizardGenerator.ts
@@ -1,0 +1,407 @@
+import { formatHoursToTime } from "@/utils/timetable";
+import type {
+  WizardCandidate,
+  WizardConflictItem,
+  WizardCourseMeeting,
+  WizardCourseOption,
+  WizardGenerationResult,
+  WizardPreferenceConditions,
+  WizardReason,
+} from "@/types/timetableWizard";
+import type {
+  WizardCourseGroup,
+  WizardGroupConditions,
+} from "@/types/timetableGroupWizard";
+
+/**
+ * 그룹 마법사(에브리타임식) 조합 생성기.
+ *
+ * 기존 generateWizardCandidates와의 핵심 차이는 "그룹" 개념이다. 기존 생성기는 위시리스트를
+ * courseId로 자동 그룹화하고 optional 그룹은 통째로 건너뛸 수 있었다. 여기서는 사용자가
+ * 직접 만든 각 그룹에서 **반드시 정확히 하나씩** 꺼내 카르테시안 곱으로 경우의 수를 만든다
+ * ("이 중 하나는 꼭 넣어야 한다"). 강의를 담은(비어있지 않은) 그룹만 조합 대상이다.
+ *
+ * 선호(C-01/03/04/05/06)는 소프트 점수, 지정요일 공강(C-02)과 제외 시간/강의는 하드 조건.
+ * 이 규칙은 기존 생성기와 동일하게 맞춰 두 플로우의 결과 해석이 어긋나지 않게 한다.
+ * 위시리스트처럼 그룹도 강의 스냅샷을 직접 들고 있어 이 함수는 순수 계산이다.
+ */
+
+const DAY_NAMES = ["월", "화", "수", "목", "금", "토", "일"];
+const SLOT_STEP = 0.5;
+const NIGHT_THRESHOLD = 18;
+const PERIOD_HOURS = 1.5;
+// 그룹 수 × 그룹당 분반 수가 커도 조합 폭발을 막는 안전장치
+const MAX_CANDIDATES = 5000;
+
+const meetingToSlots = (m: WizardCourseMeeting): string[] => {
+  const slots: string[] = [];
+  for (let t = m.startTime; t < m.endTime - 1e-6; t += SLOT_STEP) {
+    slots.push(`${m.day}-${t}`);
+  }
+  return slots;
+};
+
+const courseSlots = (course: WizardCourseOption): string[] =>
+  course.meetings.flatMap(meetingToSlots);
+
+interface HardConstraintFlags {
+  ignoreExcludedSlots?: boolean;
+  ignoreExcludedCourses?: boolean;
+  ignoreFreeDayOfWeek?: boolean;
+}
+
+interface HardCheckContext {
+  excludedSlotSet: Set<string>;
+  excludedSubjectNumberSet: Set<string>;
+  preference: WizardPreferenceConditions;
+  flags: HardConstraintFlags;
+}
+
+// 강의 하나가 이미 배치된 슬롯/제외 조건과 충돌하는지. 오전·야간 회피(C-03/C-04)는
+// 소프트 조건이라 여기서 탈락시키지 않고 buildReasons에서 점수로만 반영한다.
+const violatesHardConstraints = (
+  course: WizardCourseOption,
+  occupiedSlots: Set<string>,
+  ctx: HardCheckContext,
+): boolean => {
+  if (
+    !ctx.flags.ignoreExcludedCourses &&
+    ctx.excludedSubjectNumberSet.has(course.subjectNumber)
+  ) {
+    return true;
+  }
+
+  const { preference, flags } = ctx;
+  for (const meeting of course.meetings) {
+    if (
+      !flags.ignoreFreeDayOfWeek &&
+      preference.freeDayOfWeek.enabled &&
+      preference.freeDayOfWeek.days.includes(meeting.day)
+    ) {
+      return true; // C-02: 지정 요일에는 수업이 아예 없어야 함
+    }
+  }
+
+  const slots = courseSlots(course);
+  if (new Set(slots).size !== slots.length) return true; // 데이터 이상(자체 시간 중복) 방어
+  if (slots.some((s) => occupiedSlots.has(s))) return true; // 이미 배치된 강의와 겹침(또는 다른 그룹에서 같은 강의 중복 선택)
+  if (!ctx.flags.ignoreExcludedSlots && slots.some((s) => ctx.excludedSlotSet.has(s)))
+    return true;
+
+  return false;
+};
+
+// 각 그룹에서 정확히 하나씩 골라 만들 수 있는 모든 유효 조합(카르테시안 곱).
+// 기존 생성기와 달리 그룹을 건너뛰는 분기가 없다 - 그룹은 전부 필수다.
+const searchCombinations = (
+  groups: WizardCourseGroup[],
+  ctx: HardCheckContext,
+): WizardCourseOption[][] => {
+  const results: WizardCourseOption[][] = [];
+
+  const backtrack = (
+    index: number,
+    chosen: WizardCourseOption[],
+    occupiedSlots: Set<string>,
+  ) => {
+    if (results.length >= MAX_CANDIDATES) return;
+    if (index === groups.length) {
+      results.push(chosen);
+      return;
+    }
+
+    for (const option of groups[index].options) {
+      if (violatesHardConstraints(option, occupiedSlots, ctx)) continue;
+      const nextOccupied = new Set(occupiedSlots);
+      courseSlots(option).forEach((s) => nextOccupied.add(s));
+      backtrack(index + 1, [...chosen, option], nextOccupied);
+    }
+  };
+
+  backtrack(0, [], new Set());
+  return results;
+};
+
+const buildReasons = (
+  courses: WizardCourseOption[],
+  pref: WizardPreferenceConditions,
+): { score: number; reasons: WizardReason[] } => {
+  const reasons: WizardReason[] = [];
+  let score = 0;
+
+  const meetingsByDay: WizardCourseMeeting[][] = DAY_NAMES.map(() => []);
+  courses.forEach((c) => c.meetings.forEach((m) => meetingsByDay[m.day]?.push(m)));
+  meetingsByDay.forEach((list) => list.sort((a, b) => a.startTime - b.startTime));
+  const freeDays = meetingsByDay.map((list) => list.length === 0);
+
+  // C-02는 하드 조건이라 여기까지 온 후보는 전부 충족 상태 - 충족 사실만 표시한다.
+  if (pref.freeDayOfWeek.enabled && pref.freeDayOfWeek.days.length > 0) {
+    const names = pref.freeDayOfWeek.days.map((d) => DAY_NAMES[d]).join(", ");
+    reasons.push({
+      met: true,
+      headline: `${names}요일 공강`,
+      detail: "선택한 조건 그대로 충족했어요",
+    });
+  }
+
+  const allMeetings = courses.flatMap((c) => c.meetings);
+
+  // C-03 오전 수업 없음 (소프트)
+  if (pref.noMorningClasses.enabled) {
+    const startAfter = pref.noMorningClasses.startAfter;
+    const earlyMeetings = allMeetings.filter((m) => m.startTime < startAfter);
+    if (earlyMeetings.length === 0) {
+      score += 3;
+      reasons.push({
+        met: true,
+        headline: `오전 수업 없음 (${formatHoursToTime(startAfter)} 이후 시작)`,
+        detail: "선택한 조건 그대로 충족했어요",
+      });
+    } else {
+      reasons.push({
+        met: false,
+        headline: `오전 수업 있음 (${formatHoursToTime(startAfter)} 이전 시작)`,
+        detail: "담은 강의만으로는 오전 수업을 완전히 피할 수 없어요",
+      });
+    }
+  }
+
+  // C-04 야간 수업 제외 (소프트)
+  if (pref.noNightClasses) {
+    const nightMeetings = allMeetings.filter((m) => m.startTime >= NIGHT_THRESHOLD);
+    if (nightMeetings.length === 0) {
+      score += 3;
+      reasons.push({
+        met: true,
+        headline: "야간 수업 없음",
+        detail: "18시 이후 시작하는 수업이 없어요",
+      });
+    } else {
+      reasons.push({
+        met: false,
+        headline: "야간 수업 포함",
+        detail: `${nightMeetings.length}개 수업이 18시 이후에 시작해요`,
+      });
+    }
+  }
+
+  // C-01 공강 많은 시간표 (소프트: 많을수록 가점)
+  if (pref.manyFreeDays) {
+    const freeDayCount = freeDays.filter(Boolean).length;
+    score += freeDayCount * 1.5;
+    if (freeDayCount > 0) {
+      const names = DAY_NAMES.filter((_, i) => freeDays[i]).join(", ");
+      reasons.push({
+        met: true,
+        headline: `${names}요일 공강`,
+        detail: "담은 강의로 만들 수 있는 공강을 최대한 확보했어요",
+      });
+    } else {
+      reasons.push({
+        met: false,
+        headline: "공강 없음",
+        detail: "담은 강의만으로는 공강을 만들 수 없어요",
+      });
+    }
+  }
+
+  // C-05 연강 적은 시간표 (소프트, 90분/교시로 근사)
+  if (pref.fewConsecutive) {
+    let maxPeriods = 0;
+    let maxDay = -1;
+    meetingsByDay.forEach((list, day) => {
+      let blockStart: number | null = null;
+      let blockEnd: number | null = null;
+      const flushBlock = () => {
+        if (blockStart === null || blockEnd === null) return;
+        const periods = Math.max(1, Math.round((blockEnd - blockStart) / PERIOD_HOURS));
+        if (periods > maxPeriods) {
+          maxPeriods = periods;
+          maxDay = day;
+        }
+      };
+      list.forEach((m) => {
+        if (blockEnd !== null && Math.abs(m.startTime - blockEnd) < 0.01) {
+          blockEnd = m.endTime;
+        } else {
+          flushBlock();
+          blockStart = m.startTime;
+          blockEnd = m.endTime;
+        }
+      });
+      flushBlock();
+    });
+
+    if (maxPeriods <= 2) {
+      score += 2;
+      reasons.push({
+        met: true,
+        headline: `연강 최대 ${maxPeriods}개`,
+        detail: "3연강 이상 구간이 없어요",
+      });
+    } else {
+      reasons.push({
+        met: false,
+        headline: `연강 최대 ${maxPeriods}개`,
+        detail: `${DAY_NAMES[maxDay]}요일에 연속 강의 구간이 있어요`,
+      });
+    }
+  }
+
+  // C-06 통학 시간 피하기 (소프트: 하루 등교 체류 시간을 대리 지표로)
+  if (pref.avoidCommute) {
+    let maxSpan = 0;
+    let maxSpanDay = -1;
+    meetingsByDay.forEach((list, day) => {
+      if (list.length === 0) return;
+      const span = list[list.length - 1].endTime - list[0].startTime;
+      if (span > maxSpan) {
+        maxSpan = span;
+        maxSpanDay = day;
+      }
+    });
+
+    if (maxSpanDay === -1 || maxSpan <= 6) {
+      score += 1;
+      reasons.push({
+        met: true,
+        headline: "등하교 부담 적음",
+        detail: "하루 체류 시간이 6시간 이하예요",
+      });
+    } else {
+      reasons.push({
+        met: false,
+        headline: "등하교 부담 있는 날 포함",
+        detail: `${DAY_NAMES[maxSpanDay]}요일 체류 시간이 ${Math.round(maxSpan * 10) / 10}시간이에요`,
+      });
+    }
+  }
+
+  return { score, reasons };
+};
+
+const makeContext = (
+  conditions: WizardGroupConditions,
+  flags: HardConstraintFlags = {},
+): HardCheckContext => ({
+  excludedSlotSet: new Set(conditions.exclusion.excludedSlots),
+  excludedSubjectNumberSet: new Set(
+    conditions.exclusion.excludedCourses.map((c) => c.subjectNumber),
+  ),
+  preference: conditions.preference,
+  flags,
+});
+
+export const generateGroupWizardCandidates = (
+  conditions: WizardGroupConditions,
+): WizardGenerationResult => {
+  const { basic } = conditions;
+  // 강의가 하나라도 담긴 그룹만 조합 대상. 빈 그룹은 "선택지 없음"이라 조용히 건너뛴다.
+  const groups = basic.groups.filter((g) => g.options.length > 0);
+
+  if (groups.length === 0) {
+    return {
+      candidates: [],
+      conflicts: [{ label: "각 그룹에 강의를 1개 이상 담아주세요" }],
+    };
+  }
+
+  const baseCtx = makeContext(conditions);
+  const full = searchCombinations(groups, baseCtx);
+
+  const withinCredit = full.filter((courses) => {
+    const total = courses.reduce((s, c) => s + c.credit, 0);
+    return total >= basic.minCredit && total <= basic.maxCredit;
+  });
+
+  if (withinCredit.length === 0) {
+    const conflicts: WizardConflictItem[] = [];
+
+    if (full.length === 0) {
+      // 하드 조건을 하나씩 완화해보고, 완화 시 결과가 생기는 조건만 원인으로 지목한다
+      const { preference, exclusion } = conditions;
+      const relaxationChecks: { label: string; flags: HardConstraintFlags }[] = [];
+
+      if (exclusion.excludedSlots.length > 0) {
+        relaxationChecks.push({
+          label: `제외한 시간대 (${new Set(exclusion.excludedSlots).size}칸)`,
+          flags: { ignoreExcludedSlots: true },
+        });
+      }
+      if (exclusion.excludedCourses.length > 0) {
+        relaxationChecks.push({
+          label: `제외한 강의 (${exclusion.excludedCourses.length}개)`,
+          flags: { ignoreExcludedCourses: true },
+        });
+      }
+      if (preference.freeDayOfWeek.enabled && preference.freeDayOfWeek.days.length > 0) {
+        const names = preference.freeDayOfWeek.days.map((d) => DAY_NAMES[d]).join(", ");
+        relaxationChecks.push({
+          label: `${names}요일 공강`,
+          flags: { ignoreFreeDayOfWeek: true },
+        });
+      }
+
+      for (const check of relaxationChecks) {
+        const relaxed = searchCombinations(groups, makeContext(conditions, check.flags));
+        if (relaxed.length > 0) conflicts.push({ label: check.label });
+      }
+
+      if (conflicts.length === 0) {
+        conflicts.push({ label: "각 그룹에서 하나씩 골라도 시간이 서로 겹쳐요" });
+      }
+    } else {
+      // 하드 조건은 통과하지만 목표 학점 범위를 못 맞춤
+      const achievable = [
+        ...new Set(full.map((courses) => courses.reduce((s, c) => s + c.credit, 0))),
+      ].sort((a, b) => a - b);
+      conflicts.push({
+        label: `목표 학점 범위 (${basic.minCredit}~${basic.maxCredit}학점) - 그룹 조합으로 가능한 학점: ${achievable.join(", ")}학점`,
+      });
+    }
+
+    return { candidates: [], conflicts };
+  }
+
+  const scored = withinCredit.map((courses) => {
+    const { score, reasons } = buildReasons(courses, conditions.preference);
+    const totalCredit = courses.reduce((s, c) => s + c.credit, 0);
+    const signature = courses
+      .map((c) => c.subjectNumber)
+      .sort()
+      .join(",");
+    return { courses, totalCredit, score, reasons, signature };
+  });
+
+  // 서로 다른 그룹 배치가 같은 시간표를 만들 수 있으니 시그니처로 중복 제거
+  const seenSignatures = new Set<string>();
+  const unique = scored.filter((t) => {
+    if (seenSignatures.has(t.signature)) return false;
+    seenSignatures.add(t.signature);
+    return true;
+  });
+
+  // 모든 그룹을 채운 조합만 나오므로(그룹 건너뛰기 없음) 과목 수는 전부 같다 - 선호 점수로만 정렬
+  unique.sort((a, b) => b.score - a.score);
+
+  const labels = ["A", "B", "C"];
+  const candidates: WizardCandidate[] = unique.slice(0, 3).map((t, index) => ({
+    id: labels[index],
+    label: `시안 ${labels[index]}`,
+    courses: t.courses,
+    totalCredit: t.totalCredit,
+    reasons:
+      t.reasons.length > 0
+        ? t.reasons
+        : [
+            {
+              met: true,
+              headline: `${t.totalCredit}학점 · ${t.courses.length}과목`,
+              detail: "목표 학점 범위를 만족해요",
+            },
+          ],
+    recommended: index === 0,
+  }));
+
+  return { candidates, conflicts: [] };
+};


### PR DESCRIPTION
## 개요

기존 시간표 마법사(듣고 싶은 강의를 담아 겹치지 않게 자동 조합)와 **별개로**, 에브리타임의 시간표 마법사처럼 **그룹 1~N 각각에서 강의를 하나씩 꺼내 조합**하는 새로운 플로우를 추가합니다.

"이 중 하나는 꼭 넣는다" 식으로, 시간은 무관하지만 꼭 듣고 싶은 강의들(예: 같은 과목의 여러 분반, 또는 골프/필라테스처럼 목적이 같은 다른 과목들)을 한 그룹에 담아두면 됩니다.

동작:
1. 그룹마다 강의를 1개 이상 담기
2. 각 그룹에서 정확히 하나씩 꺼내 카르테시안 곱으로 최초 경우의 수 생성
3. 시간이 겹치는 조합을 제외하고 결과 표시

## 범위

- **"강의 선택 + 최초 경우의 수 생성"만** 새로 구성. 전체 플로우를 재작성하지 않음
- **선호조건(C-01~06)·제외조건 스텝 포함** — 기존 마법사와 동일한 3스텝 구성 유지
- **기존 마법사 관련 파일은 수정하지 않음**. 유일한 예외는 새 라우트 등록(`routes.ts` 1줄, `router.tsx` import·경로)

## 변경 사항

**신규 파일**
- `types/timetableGroupWizard.ts` — 그룹 선택 단위 타입
- `utils/timetableGroupWizardGenerator.ts` — 그룹당 정확히 하나씩 고르는(그룹 건너뛰기 없음) 조합 생성기. 시간 겹침·제외 시간/강의·지정요일 공강은 하드 필터, 나머지 선호는 소프트 점수
- `stores/useTimetableGroupWizardStore.ts` — 그룹 기반 상태(별도 persist 키로 기존 마법사와 완전 분리)
- `pages/mobile/timetable/MobileTimetableGroupWizardPage.tsx` — 오케스트레이터 페이지
- `components/mobile/timetable/wizard/group/` — `GroupWizardCourseSearchSheet`(그룹 인식 검색 시트), `GroupWizardPreferenceStep`, `GroupWizardStep3Exclusion`

**수정(추가만)**
- `constants/routes.ts` — `TIMETABLE.WIZARD_GROUP: "/timetable/wizard-group"`
- `router.tsx` — 새 페이지 라우트 등록

**재사용(무수정)**
- 결과·상세·생성중·저장·미니시간표·빈화면/에러 화면, 스텝 인디케이터, 학점 슬라이더, 공유 타입(`WizardCandidate` 등)·유틸·훅·필터 패널

## 진입점

이번 PR은 **라우트만 추가**합니다. 현재는 `/timetable/wizard-group` 경로로 직접 접근해 사용할 수 있으며, UI 진입 버튼은 포함하지 않았습니다.

## 검증

- `tsc --noEmit` 통과, `vite build` 성공
- 신규 작성 파일 전부 ESLint 통과(`--max-warnings 0`)

> 참고: `router.tsx` 하단(333~392줄)의 `@typescript-eslint/no-explicit-any` 6건은 `origin/main`에 이미 존재하던 기존 코드로, 이번 변경과 무관하여 건드리지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4WHKn4e84jmVs5EufZAFA

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4WHKn4e84jmVs5EufZAFA)_