### PR TITLE
fix: 강의 검색 필터가 멀티 웹뷰 복귀 시 반영되지 않던 문제

### DIFF
--- a/src/components/mobile/timetable/MobileCourseSearchSheet.tsx
+++ b/src/components/mobile/timetable/MobileCourseSearchSheet.tsx
@@ -16,13 +16,10 @@ import {
 import FloatingSearchBar, {
   FloatingSearchBarRef,
 } from "@/components/mobile/common/FloatingSearchBar";
-import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { ROUTES } from "@/constants/routes";
 import { mixpanelTrack } from "@/utils/mixpanel";
-import {
-  FilterState,
-  DEFAULT_FILTERS,
-} from "@/pages/mobile/timetable/MobileCourseFilterPage";
+import { useEffectiveCourseFilters } from "@/stores/useCourseFilterStore";
 import { mapFilterToOfferingFilters } from "@/utils/courseSearchResult";
 import Skeleton from "@/components/common/Skeleton";
 
@@ -97,17 +94,13 @@ interface MobileCourseSearchSheetProps {
   // 시간표 편집 화면은 강의 추가 도중 실수로 닫히지 않도록 스와이프/배경탭 dismiss를
   // 막아야 하고(기본값), 마법사의 위시리스트 검색은 반대로 자유롭게 닫을 수 있어야 한다.
   dismissible?: boolean;
-  initialFilters?: FilterState;
   onAddCourse?: (course: CourseResult) => void;
-  // 전공/영역 필터 등 서버 조회가 필요한 필터는 상위에서 querystring으로 다시 조회해야 하므로 변경을 알림
-  onFiltersChange?: (filters: FilterState) => void;
   addedCourseOfferingIds?: Set<number>;
   addedCourseIds?: Set<string>;
   isLoading?: boolean;
   hasNextPage?: boolean;
   fetchNextPage?: () => void;
   isFetchingNextPage?: boolean;
-  filterStorageKey?: string;
 }
 
 const MobileCourseSearchSheet = ({
@@ -119,32 +112,22 @@ const MobileCourseSearchSheet = ({
   open,
   onOpenChange,
   dismissible = false,
-  initialFilters = DEFAULT_FILTERS,
   onAddCourse,
-  onFiltersChange,
   addedCourseOfferingIds,
   addedCourseIds,
   isLoading = false,
   hasNextPage,
   fetchNextPage,
   isFetchingNextPage,
-  filterStorageKey = "timetable_course_filters",
 }: MobileCourseSearchSheetProps) => {
   const navigate = useNavigate();
-  const location = useLocation();
   const [isAnimating, setIsAnimating] = useState(false);
 
-  const [activeFilters, setActiveFiltersState] =
-    useState<FilterState>(initialFilters);
-
-  useEffect(() => {
-    setActiveFiltersState(initialFilters);
-  }, [initialFilters]);
-
-  const setActiveFilters = (filters: FilterState) => {
-    setActiveFiltersState(filters);
-    onFiltersChange?.(filters);
-  };
+  // 확정 필터는 useCourseFilterStore가 소유한다. 필터 화면이 별도 웹뷰로 뜨는
+  // 멀티 웹뷰 환경에서도 broadcastSync가 값을 실어오므로, 이 시트는 읽기만 한다.
+  // 부모(편집 화면)가 서버 조회에 쓰는 것과 반드시 같은 파생을 써야 한다 —
+  // 아래 filteredCourses가 같은 필터로 2차 로컬 필터링을 하기 때문이다.
+  const activeFilters = useEffectiveCourseFilters();
 
   const sheetRef = useRef<SheetRef | null>(null);
 
@@ -159,89 +142,22 @@ const MobileCourseSearchSheet = ({
     initialSnapRef.current = initialSnap;
   }, [initialSnap]);
 
-  const openRef = useRef(open);
+  // 필터 화면에서 돌아왔을 때 시트가 바닥으로 내려가 있지 않도록 지정된 snap으로 되돌린다.
+  // (예전에는 localStorage 복원 로직이 이 일을 겸했다.)
+  const isFirstFilterRender = useRef(true);
   useEffect(() => {
-    openRef.current = open;
-  }, [open]);
-
-  const onOpenChangeRef = useRef(onOpenChange);
-  useEffect(() => {
-    onOpenChangeRef.current = onOpenChange;
-  }, [onOpenChange]);
-
-  // listen to returned filters from filter page (LocalStorage & window focus & storage & visibilitychange & location fallback)
-  useEffect(() => {
-    const restoreFilters = () => {
-      const savedFilters = localStorage.getItem("applied_filters");
-      if (savedFilters) {
-        try {
-          const parsed = JSON.parse(savedFilters);
-          setActiveFilters(parsed);
-          if (!openRef.current) {
-            onOpenChangeRef.current(true);
-          }
-          // 필터 적용 후 시트 위치가 바닥(0 또는 1)으로 내려가는 것을 방지하고 지정된 snap으로 복구
-          setTimeout(() => {
-            sheetRef.current?.snapTo(initialSnapRef.current);
-          }, 50);
-        } catch (e) {
-          console.error("필터 복원 오류:", e);
-        }
-        localStorage.removeItem("applied_filters");
-        return true;
-      }
-      return false;
-    };
-
-    // 1. 컴포넌트 마운트 시도 또는 location 변경 시 확인
-    const restored = restoreFilters();
-
-    // location.state 폴백 (앱이 아닌 일반 브라우저 환경에서 데이터가 올 때를 대비)
-    if (!restored && location.state && (location.state as any).filters) {
-      setActiveFilters((location.state as any).filters);
-      if (!openRef.current) {
-        onOpenChangeRef.current(true);
-      }
-      setTimeout(() => {
-        sheetRef.current?.snapTo(initialSnapRef.current);
-      }, 50);
+    if (isFirstFilterRender.current) {
+      isFirstFilterRender.current = false;
+      return;
     }
-
-    // 2. 멀티 웹뷰 덮인 화면이 닫히며 복귀할 때를 위한 이벤트 리스너 등록
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        restoreFilters();
-      }
-    };
-
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === "applied_filters" && e.newValue) {
-        try {
-          const parsed = JSON.parse(e.newValue);
-          setActiveFilters(parsed);
-          if (!openRef.current) {
-            onOpenChangeRef.current(true);
-          }
-          setTimeout(() => {
-            sheetRef.current?.snapTo(initialSnapRef.current);
-          }, 50);
-          localStorage.removeItem("applied_filters");
-        } catch (err) {
-          console.error("필터 복원 오류:", err);
-        }
-      }
-    };
-
-    window.addEventListener("focus", restoreFilters);
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    window.addEventListener("storage", handleStorageChange);
-
-    return () => {
-      window.removeEventListener("focus", restoreFilters);
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-      window.removeEventListener("storage", handleStorageChange);
-    };
-  }, [location.state, location.key]);
+    if (!open) onOpenChange(true);
+    const timer = setTimeout(() => {
+      sheetRef.current?.snapTo(initialSnapRef.current);
+    }, 50);
+    return () => clearTimeout(timer);
+    // 확정 필터가 바뀐 순간에만 반응한다(open/onOpenChange 변화에는 반응하지 않는다).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeFilters]);
 
   const activeFilterCount = useMemo(() => {
     let count = 0;
@@ -584,12 +500,11 @@ const MobileCourseSearchSheet = ({
                 mixpanelTrack.timetableCourseSearchAction("필터 열기", {
                   result_count: filteredCourses.length,
                 });
-                navigate(ROUTES.TIMETABLE.FILTER, {
-                  state: {
-                    filters: activeFilters,
-                    storageKey: filterStorageKey,
-                  },
-                });
+                // state는 넘기지 않는다. 멀티 웹뷰에서는 이 이동이 네이티브
+                // 웹뷰 push(appBridge.navigateTo)로 위임되고 브릿지 payload는
+                // { path, url }뿐이라 state가 사라진다. 필터 화면은 양쪽 환경 모두
+                // useCourseFilterStore에서 현재 필터를 읽는다.
+                navigate(ROUTES.TIMETABLE.FILTER);
               }}
             >
               <SlidersHorizontal size={20} />

--- a/src/pages/mobile/MobileTimeTableEditPage.tsx
+++ b/src/pages/mobile/MobileTimeTableEditPage.tsx
@@ -8,7 +8,7 @@ import MobileCourseSearchSheet, {
 } from "@/components/mobile/timetable/MobileCourseSearchSheet";
 import TooltipMessage from "@/components/common/TooltipMessage";
 import { DESKTOP_MEDIA, MOBILE_PAGE_GUTTER } from "@/styles/responsive";
-import { useNavigate, useSearchParams, useLocation } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { ROUTES } from "@/constants/routes";
 import { useCourses } from "@/hooks/useCourses";
 import { useCourseOfferings } from "@/hooks/useCourseOfferings";
@@ -21,30 +21,14 @@ import {
 } from "@/hooks/useTimeTables";
 import { formatHoursToTime } from "@/utils/timetable";
 import type { CustomScheduleEditState } from "@/pages/mobile/timetable/MobileCourseAddPage";
-import {
-  DEFAULT_FILTERS,
-  type FilterState,
-} from "@/pages/mobile/timetable/MobileCourseFilterPage";
 import { useTimetableStore } from "@/stores/useTimetableStore";
-import useUserStore from "@/stores/useUserStore";
+import { useEffectiveCourseFilters } from "@/stores/useCourseFilterStore";
 import { useTimetableUrlSync } from "@/hooks/useTimetableUrlSync";
 import {
   mapCourseOfferingToCourseResult,
   mapFilterToOfferingFilters,
 } from "@/utils/courseSearchResult";
 import { mixpanelTrack } from "@/utils/mixpanel";
-
-const TIMETABLE_COURSE_FILTERS_KEY = "timetable_course_filters";
-
-const readStoredFilters = (): FilterState => {
-  try {
-    const saved = localStorage.getItem(TIMETABLE_COURSE_FILTERS_KEY);
-    if (saved) return { ...DEFAULT_FILTERS, ...JSON.parse(saved) };
-  } catch (error) {
-    console.error("시간표 강의 필터 복원 오류:", error);
-  }
-  return DEFAULT_FILTERS;
-};
 
 // --- SVG Icons from Figma ---
 const IconsAddPlus = () => (
@@ -173,39 +157,18 @@ const MobileTimeTableEditPage = () => {
     return set;
   }, [timetable]);
 
-  // 전공/영역·학년·이수구분·학점 필터
-  const location = useLocation();
-  const userDepartment = useUserStore((state) => state.userInfo.department);
-  const defaultMajor = userDepartment || "컴퓨터공학부";
-
-  const getEffectiveFilters = (): FilterState => {
-    const stored = readStoredFilters();
-    return {
-      ...stored,
-      major: stored.major ?? defaultMajor,
-    };
-  };
-
-  const [activeFilters, setActiveFilters] =
-    useState<FilterState>(getEffectiveFilters);
-
-  // 복귀 시 localStorage의 저장된 필터와 즉시 동기화
-  useEffect(() => {
-    setActiveFilters(getEffectiveFilters());
-  }, [location.key, defaultMajor]);
+  // 전공/영역·학년·이수구분·학점 필터.
+  //
+  // 확정 필터는 useCourseFilterStore가 소유한다. 필터 화면(/timetable/filter)은 멀티
+  // 웹뷰에서 별도 웹뷰로 push되므로 이 웹뷰에는 라우팅 이벤트가 오지 않는다 —
+  // location.key도 변하지 않아 예전의 "복귀 시 localStorage 재동기화"는 애초에
+  // 재실행되지 않았다. broadcastSync가 웹뷰를 건너 값을 실어온다.
+  const activeFilters = useEffectiveCourseFilters();
 
   const offeringFilters = useMemo(
     () => mapFilterToOfferingFilters(activeFilters),
     [activeFilters],
   );
-
-  const handleFiltersChange = (filters: FilterState) => {
-    setActiveFilters(filters);
-    localStorage.setItem(
-      TIMETABLE_COURSE_FILTERS_KEY,
-      JSON.stringify(filters),
-    );
-  };
 
   const combinedFilters: CourseOfferingFilters = useMemo(
     () => ({
@@ -592,15 +555,12 @@ const MobileTimeTableEditPage = () => {
         open={isSheetOpen}
         onOpenChange={setIsSheetOpen}
         onAddCourse={handleAddCourse}
-        initialFilters={activeFilters}
-        onFiltersChange={handleFiltersChange}
         addedCourseOfferingIds={addedCourseOfferingIds}
         addedCourseIds={addedCourseIds}
         isLoading={isSheetLoading}
         hasNextPage={hasNextPage}
         fetchNextPage={fetchNextPage}
         isFetchingNextPage={isFetchingNextPage}
-        filterStorageKey={TIMETABLE_COURSE_FILTERS_KEY}
       />
     </PageWrapper>
   );

--- a/src/pages/mobile/timetable/MobileCourseFilterPage.tsx
+++ b/src/pages/mobile/timetable/MobileCourseFilterPage.tsx
@@ -2,23 +2,18 @@ import { useState, useMemo, useEffect, useRef } from "react";
 import { flushSync } from "react-dom";
 import styled from "styled-components";
 import { RotateCcw } from "lucide-react";
-import {
-  useNavigate,
-  useLocation,
-  useBlocker,
-  useBeforeUnload,
-} from "react-router-dom";
+import { useNavigate, useBlocker, useBeforeUnload } from "react-router-dom";
 import { useHeader } from "@/context/HeaderContext";
 import { backHandler } from "@/utils/backHandler";
 import Modal from "@/components/common/Modal";
 import CapsuleButton from "@/components/common/CapsuleButton";
-import { useQueryClient } from "@tanstack/react-query";
-import { getCourseOfferingsPage } from "@/apis/courseOfferings";
 import { mixpanelTrack } from "@/utils/mixpanel";
-import { COURSE_OFFERINGS_QUERY_KEY } from "@/hooks/useCourseOfferings";
 import { useTimetableStore } from "@/stores/useTimetableStore";
 import useUserStore from "@/stores/useUserStore";
-import { mapFilterToOfferingFilters } from "@/utils/courseSearchResult";
+import {
+  useCourseFilterStore,
+  useEffectiveCourseFilters,
+} from "@/stores/useCourseFilterStore";
 import CourseFilterPanel, {
   resetTimeFilter,
 } from "@/components/mobile/timetable/filter/CourseFilterPanel";
@@ -40,24 +35,8 @@ export {
   formatSlotsToTimeStr,
 } from "@/components/mobile/timetable/filter/courseFilterModel";
 
-export const TIMETABLE_COURSE_FILTERS_KEY = "timetable_course_filters";
-
-const readStoredFilters = (
-  key: string = TIMETABLE_COURSE_FILTERS_KEY,
-): FilterState | null => {
-  try {
-    const saved = localStorage.getItem(key);
-    if (saved) return { ...DEFAULT_FILTERS, ...JSON.parse(saved) };
-  } catch (e) {
-    console.error("시간표 강의 필터 복원 오류:", e);
-  }
-  return null;
-};
-
 export default function MobileCourseFilterPage() {
   const navigate = useNavigate();
-  const location = useLocation();
-  const queryClient = useQueryClient();
   const { timetables, activeTimetableId } = useTimetableStore();
   const userDepartment = useUserStore((state) => state.userInfo.department);
   const activeTimetable = useMemo(() => {
@@ -65,28 +44,18 @@ export default function MobileCourseFilterPage() {
   }, [timetables, activeTimetableId]);
   const activeTimetableEvents = activeTimetable?.events ?? [];
   const [isApplying, setIsApplying] = useState(false);
-  const storageKey =
-    (location.state?.storageKey as string) || TIMETABLE_COURSE_FILTERS_KEY;
 
-  const defaultMajor = userDepartment || "컴퓨터공학부";
+  // 이 화면은 멀티 웹뷰에서 별도 웹뷰로 뜨므로 location.state가 오지 않는다.
+  // 현재 확정 필터는 항상 스토어에서 읽는다(persist가 콜드스타트를 책임진다).
+  const effectiveFilters = useEffectiveCourseFilters();
+  const applyFilters = useCourseFilterStore((state) => state.applyFilters);
 
-  // 상위 편집/마법사 화면에서 전달한 필터 상태가 있다면 수신, 없으면 해당 storageKey에서 복원
-  const initialFilters = useMemo(() => {
-    const stateFilters = location.state?.filters as FilterState | undefined;
-    if (stateFilters) {
-      return {
-        ...DEFAULT_FILTERS,
-        ...stateFilters,
-        major: stateFilters.major ?? defaultMajor,
-      };
-    }
-    const stored = readStoredFilters(storageKey);
-    return {
-      ...DEFAULT_FILTERS,
-      ...stored,
-      major: stored?.major ?? defaultMajor,
-    };
-  }, [location.state, storageKey, defaultMajor]);
+  // 마운트 시점의 확정 필터를 초안의 출발점으로 삼는다. 편집 도중 다른 웹뷰가
+  // 필터를 바꿔 초안이 튀는 일이 없도록 스토어 변화를 따라가지는 않는다.
+  const [initialFilters] = useState<FilterState>(() => ({
+    ...DEFAULT_FILTERS,
+    ...effectiveFilters,
+  }));
 
   const [filters, setFilters] = useState<FilterState>(initialFilters);
   const [view, setSubView] = useState<FilterSubView>("main");
@@ -104,25 +73,9 @@ export default function MobileCourseFilterPage() {
   const [isSaving, setIsSaving] = useState(false);
   const isSavingRef = useRef(false);
 
-  // localStorage 파열 언마운트 클린업용 제어 ref
-  const hasWrittenLocalStorageRef = useRef(false);
-  const initialFiltersRef = useRef(initialFilters);
-  useEffect(() => {
-    initialFiltersRef.current = initialFilters;
-  }, [initialFilters]);
-
-  // 컴포넌트가 언마운트될 때, 저장하지 않고 나가는 맰 경우 initialFilters를 localStorage에 복원
-  // (헤더 뿯로가기, 브라우저 뿯로가기, OS 백키 등 모든 이탈 경로에서 필터 상태를 보장)
-  useEffect(() => {
-    return () => {
-      if (!hasWrittenLocalStorageRef.current) {
-        localStorage.setItem(
-          "applied_filters",
-          JSON.stringify(initialFiltersRef.current),
-        );
-      }
-    };
-  }, []);
+  // 저장하지 않고 나가는 경로(헤더 뒤로가기, OS 백키, 브라우저 뒤로가기)를 위한 복원
+  // 로직은 더 이상 필요 없다. 초안은 이 화면의 로컬 state이고 확정 필터는 applyFilters를
+  // 부를 때만 바뀌므로, 그냥 나가면 스토어가 손대지지 않은 채로 남는다.
 
   // 초기 상태 대비 변경 사항이 존재하는지 깊은 비교
   const hasChanges = useMemo(() => {
@@ -163,9 +116,7 @@ export default function MobileCourseFilterPage() {
     setShowUnsavedModal(false);
     backHandler.setPageUnsavedChanges(false);
 
-    // 변경 전 원본 필터를 localStorage에 복원하여 시트가 올바른 상태를 읽도록 함
-    hasWrittenLocalStorageRef.current = true;
-    localStorage.setItem("applied_filters", JSON.stringify(initialFilters));
+    // 확정 필터(스토어)는 애초에 건드리지 않았으므로 되돌릴 것이 없다.
 
     if (blocker.state === "blocked") {
       blocker.proceed();
@@ -326,66 +277,38 @@ export default function MobileCourseFilterPage() {
     setFilters((prev) => resetTimeFilter(prev));
   };
 
-  // 저장하기 핸들러 (서버 재조회 후 렌더링 준비 완료 시 편집 페이지로 복귀)
-  const handleSave = async () => {
+  // 저장하기 핸들러.
+  //
+  // 예전에는 여기서 개설강의를 미리 fetch한 뒤 복귀했는데, 멀티 웹뷰에서 이 화면은
+  // 편집 화면과 다른 JS 런타임이라 그 prefetch는 **이 웹뷰의** QueryClient만 데웠다.
+  // 복귀만 그만큼 느려질 뿐이라 걷어냈다(편집 화면은 확정 필터를 받는 즉시 자기
+  // 쿼리를 돌리고, 성공 데이터는 queryBroadcastSync가 웹뷰 간에 실어 나른다).
+  const handleSave = () => {
     if (isApplying) return;
     setIsApplying(true);
 
-    try {
-      const offeringFilters = mapFilterToOfferingFilters(filters);
+    backHandler.setPageUnsavedChanges(false); // 앱 환경의 native back 이벤트 방어
+    isSavingRef.current = true;
+    setShowUnsavedModal(false);
 
-      if (activeTimetable?.year && activeTimetable?.term) {
-        await queryClient.fetchInfiniteQuery({
-          queryKey: [
-            ...COURSE_OFFERINGS_QUERY_KEY,
-            activeTimetable.year,
-            activeTimetable.term,
-            offeringFilters.deptName ?? "",
-            offeringFilters.collegeName ?? "",
-            offeringFilters.hyNames?.join(",") ?? "",
-            offeringFilters.isuNames?.join(",") ?? "",
-            offeringFilters.isuFldNames?.join(",") ?? "",
-            offeringFilters.ssupTypeNames?.join(",") ?? "",
-            offeringFilters.credits?.join(",") ?? "",
-            offeringFilters.keyword ?? "",
-            offeringFilters.meetingFilterMode ?? "",
-            offeringFilters.meetings?.join(",") ?? "",
-          ],
-          queryFn: ({ pageParam = 0 }) =>
-            getCourseOfferingsPage(
-              activeTimetable.year,
-              activeTimetable.term,
-              pageParam as number,
-              50,
-              offeringFilters,
-            ),
-          initialPageParam: 0,
-        });
-      }
-    } catch (error) {
-      console.error("필터 데이터 사전 조회 오류:", error);
-    } finally {
-      hasWrittenLocalStorageRef.current = true; // 언마운트 cleanup 덮어쓰기 방지
-      backHandler.setPageUnsavedChanges(false); // 앱 환경의 native back 이벤트 방어
-      isSavingRef.current = true;
-      setShowUnsavedModal(false);
-      localStorage.setItem("applied_filters", JSON.stringify(filters));
-      localStorage.setItem(storageKey, JSON.stringify(filters));
-      mixpanelTrack.timetableCourseSearchAction("필터 적용", {
-        has_major: Boolean(filters.major),
-        has_time:
-          filters.time !== "전체 시간" ||
-          Boolean(filters.selectedSlots?.length),
-        grade_count: filters.grades.length,
-        type_count: filters.types.length,
-        credit_count: filters.credits.length,
-        sort: filters.sort,
-      });
-      flushSync(() => {
-        setIsSaving(true); // blocker 비활성화 후 navigate
-      });
-      navigate(-1);
-    }
+    // 확정 필터 갱신. broadcastSync가 다른 웹뷰(편집 화면)로 실어 나르고,
+    // persist가 localStorage에 남긴다.
+    applyFilters(filters);
+
+    mixpanelTrack.timetableCourseSearchAction("필터 적용", {
+      has_major: Boolean(filters.major),
+      has_time:
+        filters.time !== "전체 시간" || Boolean(filters.selectedSlots?.length),
+      grade_count: filters.grades.length,
+      type_count: filters.types.length,
+      credit_count: filters.credits.length,
+      sort: filters.sort,
+    });
+
+    flushSync(() => {
+      setIsSaving(true); // blocker 비활성화 후 navigate
+    });
+    navigate(-1);
   };
 
   // 즐겨찾기 별표 토글

--- a/src/stores/middleware/broadcastSync.ts
+++ b/src/stores/middleware/broadcastSync.ts
@@ -19,6 +19,21 @@ interface BroadcastSyncOptions<T> {
  * api.setState(브로드캐스트 미발신)를 분리하는 것만으로 재전송 루프가 생기지
  * 않는다.
  */
+/**
+ * 채널 이름 → 대기 중인 브로드캐스트를 즉시 내보내는 함수.
+ *
+ * 아래 broadcastingSet은 한 틱의 set()들을 마이크로태스크로 병합해 1회만 보낸다.
+ * 그런데 "상태를 바꾸고 곧바로 이 웹뷰를 떠나는" 흐름(필터 저장 후 goBack)에서는
+ * 그 지연이 치명적이다 — 떠나는 요청이 동기적으로 먼저 네이티브에 도착해 웹뷰가
+ * pop되고, 뒤늦게 나가는 브로드캐스트는 유실된다. 그런 호출부는 이 함수로 병합을
+ * 건너뛰고 즉시 내보낸 뒤 이동해야 한다(브릿지 메시지는 FIFO라 순서가 보장된다).
+ */
+const pendingFlushers = new Map<string, () => void>();
+
+export function flushBroadcastSync(name: string): void {
+  pendingFlushers.get(name)?.();
+}
+
 export function broadcastSync<T extends object>(options: BroadcastSyncOptions<T>) {
   return (creator: StateCreator<T, [], []>): StateCreator<T, [], []> =>
     (set, get, api: StoreApi<T>) => {
@@ -39,6 +54,22 @@ export function broadcastSync<T extends object>(options: BroadcastSyncOptions<T>
       let pendingBroadcastTimer: Promise<void> | null = null;
       let lastBroadcastSerialized: string | null = null;
 
+      const sendNow = () => {
+        const nextPartial = options.partialize(get());
+        const serialized = JSON.stringify(nextPartial);
+
+        if (serialized !== lastBroadcastSerialized) {
+          lastBroadcastSerialized = serialized;
+          channel.postMessage(nextPartial);
+        }
+      };
+
+      // 이 웹뷰를 떠나기 직전의 호출부가 병합을 건너뛰고 즉시 내보낼 수 있게 한다.
+      pendingFlushers.set(options.name, () => {
+        pendingBroadcastTimer = null; // 예약된 마이크로태스크는 중복 전송하지 않도록 무력화
+        sendNow();
+      });
+
       const broadcastingSet: typeof set = (...args) => {
         set(...args);
 
@@ -46,14 +77,9 @@ export function broadcastSync<T extends object>(options: BroadcastSyncOptions<T>
         // 단일 이벤트 루프 틱 안에서 연속 호출된 set()을 하나로 병합하여 1회만 전송
         if (!pendingBroadcastTimer) {
           pendingBroadcastTimer = Promise.resolve().then(() => {
+            if (!pendingBroadcastTimer) return; // flush가 이미 내보냈다
             pendingBroadcastTimer = null;
-            const nextPartial = options.partialize(get());
-            const serialized = JSON.stringify(nextPartial);
-
-            if (serialized !== lastBroadcastSerialized) {
-              lastBroadcastSerialized = serialized;
-              channel.postMessage(nextPartial);
-            }
+            sendNow();
           });
         }
       };

--- a/src/stores/useCourseFilterStore.ts
+++ b/src/stores/useCourseFilterStore.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
-import { broadcastSync } from "@/stores/middleware/broadcastSync";
+import { broadcastSync, flushBroadcastSync } from "@/stores/middleware/broadcastSync";
 import useUserStore from "@/stores/useUserStore";
 import {
   DEFAULT_FILTERS,
@@ -37,15 +37,23 @@ interface CourseFilterState {
   applyFilters: (filters: FilterState) => void;
 }
 
+const SYNC_CHANNEL = "course-filter-sync";
+
 export const useCourseFilterStore = create<CourseFilterState>()(
   persist(
     broadcastSync<CourseFilterState>({
-      name: "course-filter-sync",
+      name: SYNC_CHANNEL,
       // 액션은 제외하고 확정 필터만 실어 보낸다.
       partialize: (state) => ({ filters: state.filters }),
     })((set) => ({
       filters: DEFAULT_FILTERS,
-      applyFilters: (filters) => set({ filters }),
+      applyFilters: (filters) => {
+        set({ filters });
+        // 이 액션의 유일한 호출부(필터 화면 "저장")는 곧바로 goBack을 보내 자기
+        // 웹뷰를 pop시킨다. 기본 마이크로태스크 병합에 맡기면 goBack이 먼저
+        // 네이티브에 도착해 브로드캐스트가 유실되므로 여기서 즉시 내보낸다.
+        flushBroadcastSync(SYNC_CHANNEL);
+      },
     })),
     {
       name: TIMETABLE_COURSE_FILTERS_KEY,

--- a/src/stores/useCourseFilterStore.ts
+++ b/src/stores/useCourseFilterStore.ts
@@ -1,0 +1,105 @@
+import { useMemo } from "react";
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { broadcastSync } from "@/stores/middleware/broadcastSync";
+import useUserStore from "@/stores/useUserStore";
+import {
+  DEFAULT_FILTERS,
+  type FilterState,
+} from "@/components/mobile/timetable/filter/courseFilterModel";
+
+/**
+ * 시간표 편집 화면의 "확정된" 강의 검색 필터.
+ *
+ * 이 스토어가 존재하는 이유는 멀티 웹뷰다. 필터 화면(/timetable/filter)은 RN 셸에서
+ * 별도 WebView로 push되므로(router.tsx가 router.navigate를 패치해 appBridge.navigateTo로
+ * 위임한다) 편집 화면과 **다른 JS 런타임**에서 돈다. 그래서:
+ *
+ *  - `navigate(path, { state })`의 state는 브릿지를 건너지 못한다(NavigateToPayload는
+ *    { path, url }뿐). 필터 화면의 location.state는 앱에서 항상 undefined다.
+ *  - pop 시 편집 화면 웹뷰에는 SPA 라우팅이 일어나지 않아 location.key가 불변이고,
+ *    따라서 마운트/라우트 변경에 걸어둔 복원 로직은 재실행되지 않는다.
+ *  - `storage` 이벤트는 WebView 인스턴스 사이를 건너지 않는다.
+ *
+ * 그래서 확정 필터를 in-memory 컴포넌트 상태가 아니라 broadcastSync 스토어가 소유한다.
+ * 필터 화면이 applyFilters를 부르면 BroadcastChannel + 네이티브 브릿지 릴레이 이중
+ * 경로로 편집 화면 웹뷰에 즉시 도달한다(useUserStore가 로그인 화면에 대해 쓰는 것과
+ * 같은 방식). persist는 콜드스타트 복원용이다.
+ *
+ * 편집 중인 초안(draft)은 여기 두지 않는다. 필터 화면이 로컬 useState로 들고 있다가
+ * "저장"에서만 applyFilters를 부르므로, 토글 하나하나가 브로드캐스트되지 않는다.
+ */
+
+export const TIMETABLE_COURSE_FILTERS_KEY = "timetable_course_filters";
+
+interface CourseFilterState {
+  filters: FilterState;
+  applyFilters: (filters: FilterState) => void;
+}
+
+export const useCourseFilterStore = create<CourseFilterState>()(
+  persist(
+    broadcastSync<CourseFilterState>({
+      name: "course-filter-sync",
+      // 액션은 제외하고 확정 필터만 실어 보낸다.
+      partialize: (state) => ({ filters: state.filters }),
+    })((set) => ({
+      filters: DEFAULT_FILTERS,
+      applyFilters: (filters) => set({ filters }),
+    })),
+    {
+      name: TIMETABLE_COURSE_FILTERS_KEY,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ filters: state.filters }) as CourseFilterState,
+      // 저장 포맷이 { state: { filters } }라 예전의 평평한 FilterState와 다르다.
+      // 구 포맷이 남아 있으면 persist가 filters를 못 찾으므로 기본값으로 시작한다
+      // (필터를 한 번 다시 적용하면 새 포맷으로 저장된다).
+      merge: (persisted, current) => {
+        const saved = (persisted ?? {}) as Partial<CourseFilterState>;
+        return {
+          ...current,
+          filters: saved.filters
+            ? { ...DEFAULT_FILTERS, ...saved.filters }
+            : current.filters,
+        };
+      },
+    },
+  ),
+);
+
+const FALLBACK_MAJOR = "컴퓨터공학부";
+
+/**
+ * 화면이 실제로 조회에 쓰는 필터.
+ *
+ * 저장된 major가 없으면 사용자 학과로 채운다. 편집 화면(서버 조회)과 검색 시트(받아온
+ * 목록의 2차 로컬 필터링)가 반드시 같은 값을 봐야 하므로 이 파생을 한 곳에서만 정의한다.
+ */
+export const useEffectiveCourseFilters = (): FilterState => {
+  const filters = useCourseFilterStore((state) => state.filters);
+  const userDepartment = useUserStore((state) => state.userInfo.department);
+
+  return useMemo(
+    () => ({
+      ...filters,
+      major: filters.major ?? (userDepartment || FALLBACK_MAJOR),
+    }),
+    [filters, userDepartment],
+  );
+};
+
+/**
+ * 브릿지 릴레이가 없는 셸(구 네이티브 앱: bridgeChannel === null 인데 멀티 웹뷰 push는
+ * 하는 조합)에서는 BroadcastChannel 한 경로만 남고, WKWebView에서는 그마저 웹뷰 간
+ * 전달이 불안정하다. 그 경우를 위해 화면이 다시 앞으로 올라올 때 저장소에서 한 번 더
+ * 끌어온다. 브로드캐스트가 이미 도달했다면 값이 같아 리렌더도 일어나지 않는다.
+ */
+if (typeof window !== "undefined") {
+  const rehydrate = () => {
+    void useCourseFilterStore.persist.rehydrate();
+  };
+  window.addEventListener("focus", rehydrate);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") rehydrate();
+  });
+}


### PR DESCRIPTION
## 문제

필터 화면(`/timetable/filter`)은 RN 셸에서 **별도 WebView로 push**된다(`router.tsx`가 `router.navigate`를 패치해 `appBridge.navigateTo`로 위임). 즉 편집 화면과 다른 JS 런타임에서 돌기 때문에 기존 핸드오프가 다음과 같이 어긋나 있었다.

- `navigate(path, { state })`의 `state`가 브릿지를 건너지 못한다. `NavigateToPayload`는 `{ path, url }`뿐이라 필터 화면의 `location.state`는 앱에서 **항상 undefined**였다.
- pop 시 편집 화면 웹뷰에는 SPA 라우팅이 없어 `location.key`가 불변이므로, 마운트/라우트 변경에 걸어둔 복원 로직이 재실행되지 않았다.
- `storage` 이벤트는 WebView 인스턴스 사이를 건너지 않는다(`multiWebViewChannel`이 네이티브 릴레이를 두는 이유와 동일).
- `handleSave`의 `fetchInfiniteQuery`는 **필터 웹뷰의** QueryClient만 데우고 복귀만 지연시켰다.

결과적으로 필터 반영이 `focus`/`visibilitychange`가 우연히 발화하는지에 달려 있었다.

## 변경

확정 필터를 `useCourseFilterStore`(`broadcastSync` + `persist`)가 소유하도록 이관했다. `useUserStore`가 로그인 화면에 대해 쓰는 것과 같은 방식으로, BroadcastChannel + 네이티브 브릿지 릴레이 **이중 경로**로 편집 화면 웹뷰에 도달한다.

초안은 필터 화면의 로컬 state로 남아 "저장"에서만 `applyFilters`를 부른다. 저장 없이 나가면 되돌릴 것이 없으므로 복원 로직 일체를 삭제했다.

**두 번째 커밋**: 이관만으로는 실기기에서 여전히 반영되지 않았다. `broadcastSync`는 postMessage를 마이크로태스크로 병합하는데 `handleSave`는 직후 **동기적으로** `goBack`을 보낸다 → 브릿지에 `goBack`이 먼저 도착해 웹뷰가 pop된 뒤 브로드캐스트가 출발 → 유실. `flushBroadcastSync(name)`을 추가해 떠나기 직전 호출부가 즉시 내보내도록 했다(브릿지 메시지는 FIFO).

## 지운 것

- 시트의 복원 블록 전체(`applied_filters` 마요일함 + 4중 리스너)
- 필터 페이지의 언마운트 복원 effect, 미저장 이탈 시 원본 되돌리기
- `readStoredFilters` × 2벌, `TIMETABLE_COURSE_FILTERS_KEY` × 2벌 (중복 정의였음)
- `handleSave`의 `await fetchInfiniteQuery`
- `initialFilters` / `onFiltersChange` / `filterStorageKey` prop 3종

순변화 **+190 / -287**.

## 검증 (iOS 시뮬레이터, idb)

- 필터 화면이 별도 웹뷰로 push되고 초안이 스토어에서 시드됨
- 학년 추가 후 적용 → 편집 화면 배지 "필터 1" → "필터 2"
- `focus`/`visibilitychange` 폴백을 임시로 끈 A/B에서도 "필터 2" → "필터 3"
  → **브로드캐스트 경로가 실제로 값을 나르고 있음**(폴백 덕이 아님)
- node 하니스로 `persist` × `broadcastSync` 합성 검증(원격 수신이 persist에도 반영, 에코 루프 없음, 구 저장 포맷에서 크래시 없음)

`tsc --noEmit` 통과, `vite build` 성공.

## 리뷰 시 봐주실 점

- 저장 키를 `timetable_course_filters`로 재사용했는데 포맷이 `{state:{filters}}`로 바뀌었다. **기존 사용자의 저장된 필터는 1회 초기화**된다(크래시는 없음을 확인). 마이그레이션이 필요하면 알려주세요.
- 브릿지 릴레이가 없는 셸(구 네이티브 앱)을 위해 `focus`/`visibilitychange`에서 `persist.rehydrate()`를 한 번 돌리는 폴백만 남겼다.

https://claude.ai/code/session_01YRppGrYENAPSYgMr6iMjPj