### PR TITLE
fix: 시간표 편집이 보고 있던 시간표가 아니라 대표 시간표를 열던 문제

### DIFF
--- a/src/pages/mobile/MobileTimeTablePage.tsx
+++ b/src/pages/mobile/MobileTimeTablePage.tsx
@@ -401,7 +401,17 @@ const MobileTimeTablePage = () => {
 
     return (
       <HeaderRightArea>
-        <IconButton onClick={() => navigate(ROUTES.TIMETABLE.EDIT)}>
+        {/* 편집 대상 시간표 id를 반드시 URL로 넘긴다.
+            멀티 웹뷰에서 이 이동은 네이티브 웹뷰 push라 편집 화면이 별도 JS
+            런타임에서 뜬다. useTimetableStore는 persist를 쓰지 않으므로 그쪽
+            스토어는 빈 상태로 시작하고, setTimetables가 "대표 시간표"로 폴백해
+            (useTimetableStore.ts 참고) 보고 있던 시간표와 다른 학기가 열린다.
+            ?id= 가 있어야 useTimetableUrlSync가 올바른 시간표로 복원한다. */}
+        <IconButton
+          onClick={() =>
+            navigate(`${ROUTES.TIMETABLE.EDIT}?id=${activeTimetable.id}`)
+          }
+        >
           <Pencil size={22} color="#1C1C1E" />
         </IconButton>
       </HeaderRightArea>


### PR DESCRIPTION
## 문제

2학기 시간표를 보다가 편집을 눌러도 **1학기 시간표가 열린다.**

## 원인

멀티 웹뷰에서 이 이동은 **네이티브 웹뷰 push**라 편집 화면이 별도 JS 런타임에서 뜬다. `useTimetableStore`는 `broadcastSync`만 쓰고 **`persist`는 쓰지 않으므로** 그쪽 스토어는 `activeTimetableId: null` / `selectedSemester: ""` 로 시작하고, `setTimetables`가 **"대표 시간표"로 폴백**한다(`useTimetableStore.ts:75-91`). 브로드캐스트는 `set`이 일어날 때만 나가므로 새로 뜬 웹뷰는 부모의 현재 선택을 받지 못한다.

그런데 **편집 버튼만 `?id=`를 붙이지 않고 있었다.** (목록에서 만든 직후 이동하는 `:640`은 붙인다.)

```diff
- <IconButton onClick={() => navigate(ROUTES.TIMETABLE.EDIT)}>
+ <IconButton onClick={() => navigate(`${ROUTES.TIMETABLE.EDIT}?id=${activeTimetable.id}`)}>
```

id가 없으니 `useTimetableUrlSync`도 복원하지 못하고, 오히려 그 잘못된 값을 URL에 써넣는다.

이 계정에서는 **`"2026-2학기 하이"`(id=5)가 이름과 달리 `term: FIRST`이고 `isPrimary: true`** 라, 어떤 시간표를 보고 있었든 항상 1학기가 열렸다.

## 검증 (iOS 시뮬레이터, idb)

- 2학기 시간표(시안 A, id=24) 선택 후 편집 → 셸의 `Where am I?` 가 `url: /timetable/edit?id=24` 보고, 그리드가 2학기 시간표 내용(대학수학(2)·모바일소프트웨어·컴퓨터그래픽스·C언어)으로 뜸
- 강의 목록도 2026-2학기 개설강의로 채워짐 — **1학기는 서버에 개설강의가 0건**이라 그동안 목록이 늘 비어 있었다

## 같은 계열로 남아 있는 것 (이 PR 범위 밖)

시간표 스코프 라우트로 가는 다른 네이티브 push들도 `?id=`를 싣지 않는다. 각각 같은 폴백을 타므로 대상 시간표가 어긋날 수 있다.

- `MobileTimeTableEditPage` 헤더의 `TIMETABLE.ADD` / `TIMETABLE.WIZARD` / `TIMETABLE.VISIBILITY`
- `MobileCourseAddPage:149,170`, `MobileSyllabusPage:269` 의 `navigate(EDIT, { replace: true })` — 이쪽은 `replace`라 웹뷰 push가 아니고 같은 웹뷰 SPA 이동이라 성격이 다르다

한 번에 고치기보다 별건으로 확인하며 진행하는 편이 안전해 보여 남겨둔다.

https://claude.ai/code/session_01YRppGrYENAPSYgMr6iMjPj