### PR TITLE
fix: 시간표 타임블록 단위를 30분에서 5분으로 축소 (45분 수업 대응)

### DIFF
--- a/src/components/mobile/timetable/TimetableGrid.tsx
+++ b/src/components/mobile/timetable/TimetableGrid.tsx
@@ -68,6 +68,22 @@ const DEFAULT_MAX_HOUR = 18;
 const MIN_DAY_COUNT = 5;
 const MAX_DAY_COUNT = 7;
 
+// 수업 블록을 얹는 그리드 행 단위(분). 45분·75분처럼 30분 배수가 아닌 수업이 실제로
+// 있어서, 행을 30분으로 두면 블록이 30분 격자로 반올림돼 실제와 다른 시간에 그려졌다.
+const ROW_MINUTES = 5;
+const ROWS_PER_HOUR = 60 / ROW_MINUTES;
+// 눈에 보이는 칸(시간대 드래그 선택 단위)은 그대로 30분 — 선택 슬롯 문자열
+// (`${day}-${hour}`, hour는 0.5 단위)이 필터·마법사 제외조건과 공유하는 규약이라
+// 여기만 잘게 쪼개면 안 된다. 30분 칸 하나가 SELECT_ROWS개 행을 덮는다.
+const SELECT_STEP_HOURS = 0.5;
+const SELECT_ROWS = (SELECT_STEP_HOURS * 60) / ROW_MINUTES;
+const SELECT_CELL_HEIGHT_PX = 25;
+const ROW_HEIGHT_PX = SELECT_CELL_HEIGHT_PX / SELECT_ROWS;
+
+// 시간값(9.75 = 09:45) -> 그리드 행 번호. 1행은 요일 헤더라 +2.
+const timeToRow = (time: number) =>
+  Math.round((time - START_HOUR) * ROWS_PER_HOUR) + 2;
+
 const EMPTY_PREVIEW_EVENTS: ClassItem[] = [];
 const EMPTY_SELECTED_SLOTS: string[] = [];
 
@@ -261,7 +277,8 @@ const TimetableGrid = ({
   const timeSlots = useMemo(() => {
     const allEvents = [...timedEvents, ...timedPreviewEvents];
     const maxEventTime = Math.max(0, ...allEvents.map((e) => e.endTime));
-    const endHour = Math.max(DEFAULT_MAX_HOUR, maxEventTime);
+    // 정시에 끝나지 않는 수업(예: 18:45)도 마지막 행 안에 들어오도록 올림한다.
+    const endHour = Math.max(DEFAULT_MAX_HOUR, Math.ceil(maxEventTime));
 
     const slots = [];
     for (let i = START_HOUR; i <= endHour; i++) {
@@ -270,7 +287,7 @@ const TimetableGrid = ({
     return slots;
   }, [timedEvents, timedPreviewEvents]);
 
-  const rowCount = (timeSlots.length - 1) * 2;
+  const rowCount = (timeSlots.length - 1) * ROWS_PER_HOUR;
 
   // 2. 색상 매핑
   const themeColors = useMemo(() => {
@@ -294,8 +311,9 @@ const TimetableGrid = ({
     isPreview: boolean,
   ) => {
     const colStart = item.day + 2;
-    const rowStart = Math.round((item.startTime - START_HOUR) * 2) + 2;
-    const rowEnd = Math.round((item.endTime - START_HOUR) * 2) + 2;
+    const rowStart = timeToRow(item.startTime);
+    // 5분 미만 길이(데이터 이상)라도 최소 한 행은 차지해야 그리드가 깨지지 않는다.
+    const rowEnd = Math.max(rowStart + 1, timeToRow(item.endTime));
     // 개별 색상이 지정되어 있으면 우선 사용, 아니면 미리보기면 고정색, 기본은 맵핑된 색
     const bgColor = item.color
       ? item.color
@@ -366,70 +384,46 @@ const TimetableGrid = ({
 
         {/* (2) 시간표 바디 */}
         {timeSlots.slice(0, -1).map((time, timeIndex) => {
-          const rowIndex = timeIndex * 2 + 2;
+          const rowIndex = timeIndex * ROWS_PER_HOUR + 2;
           return (
             <React.Fragment key={`row-${time}`}>
               <TimeCell
                 style={{
                   gridColumn: 1,
                   gridRowStart: rowIndex,
-                  gridRowEnd: "span 2",
+                  gridRowEnd: `span ${ROWS_PER_HOUR}`,
                 }}
               >
                 <span>{time}</span>
               </TimeCell>
-              {/* First 30 minutes */}
-              {DAYS.map((_, dayIndex) => {
-                const timeVal = time;
-                const slot = `${dayIndex}-${timeVal}`;
-                const isSelected = localSelected.includes(slot);
-                return (
-                  <GridBackgroundCell
-                    key={`bg-${timeVal}-${dayIndex}`}
-                    $isSelectionMode={isSelectionMode}
-                    $isSelected={isSelected}
-                    $isLastDay={dayIndex === DAYS.length - 1}
-                    data-day={dayIndex}
-                    data-hour={timeVal}
-                    onTouchStart={isSelectionMode ? (e) => handleCellTouchStart(dayIndex, timeVal, e) : undefined}
-                    onTouchEnd={isSelectionMode ? handleTouchEnd : undefined}
-                    onMouseDown={isSelectionMode ? () => handleMouseDown(dayIndex, timeVal) : undefined}
-                    onMouseEnter={isSelectionMode ? () => handleMouseEnter(dayIndex, timeVal) : undefined}
-                    onMouseUp={isSelectionMode ? handleMouseUp : undefined}
-                    style={{
-                      gridColumn: dayIndex + 2,
-                      gridRowStart: rowIndex,
-                      gridRowEnd: "span 1",
-                    }}
-                  />
-                );
-              })}
-              {/* Second 30 minutes */}
-              {DAYS.map((_, dayIndex) => {
-                const timeVal = time + 0.5;
-                const slot = `${dayIndex}-${timeVal}`;
-                const isSelected = localSelected.includes(slot);
-                return (
-                  <GridBackgroundCell
-                    key={`bg-${timeVal}-${dayIndex}`}
-                    $isSelectionMode={isSelectionMode}
-                    $isSelected={isSelected}
-                    $isLastDay={dayIndex === DAYS.length - 1}
-                    data-day={dayIndex}
-                    data-hour={timeVal}
-                    onTouchStart={isSelectionMode ? (e) => handleCellTouchStart(dayIndex, timeVal, e) : undefined}
-                    onTouchEnd={isSelectionMode ? handleTouchEnd : undefined}
-                    onMouseDown={isSelectionMode ? () => handleMouseDown(dayIndex, timeVal) : undefined}
-                    onMouseEnter={isSelectionMode ? () => handleMouseEnter(dayIndex, timeVal) : undefined}
-                    onMouseUp={isSelectionMode ? handleMouseUp : undefined}
-                    style={{
-                      gridColumn: dayIndex + 2,
-                      gridRowStart: rowIndex + 1,
-                      gridRowEnd: "span 1",
-                    }}
-                  />
-                );
-              })}
+              {/* 30분 칸 두 개(정시/30분)를 각각 SELECT_ROWS행씩 덮어서 그린다 */}
+              {[0, SELECT_STEP_HOURS].map((offset, halfIndex) =>
+                DAYS.map((_, dayIndex) => {
+                  const timeVal = time + offset;
+                  const slot = `${dayIndex}-${timeVal}`;
+                  const isSelected = localSelected.includes(slot);
+                  return (
+                    <GridBackgroundCell
+                      key={`bg-${timeVal}-${dayIndex}`}
+                      $isSelectionMode={isSelectionMode}
+                      $isSelected={isSelected}
+                      $isLastDay={dayIndex === DAYS.length - 1}
+                      data-day={dayIndex}
+                      data-hour={timeVal}
+                      onTouchStart={isSelectionMode ? (e) => handleCellTouchStart(dayIndex, timeVal, e) : undefined}
+                      onTouchEnd={isSelectionMode ? handleTouchEnd : undefined}
+                      onMouseDown={isSelectionMode ? () => handleMouseDown(dayIndex, timeVal) : undefined}
+                      onMouseEnter={isSelectionMode ? () => handleMouseEnter(dayIndex, timeVal) : undefined}
+                      onMouseUp={isSelectionMode ? handleMouseUp : undefined}
+                      style={{
+                        gridColumn: dayIndex + 2,
+                        gridRowStart: rowIndex + halfIndex * SELECT_ROWS,
+                        gridRowEnd: `span ${SELECT_ROWS}`,
+                      }}
+                    />
+                  );
+                }),
+              )}
             </React.Fragment>
           );
         })}
@@ -448,10 +442,11 @@ const TimetableGrid = ({
             style={{
               gridColumnStart: highlightedSlot.day + 2,
               gridColumnEnd: "span 1",
-              gridRowStart:
-                Math.round((highlightedSlot.startTime - START_HOUR) * 2) + 2,
-              gridRowEnd:
-                Math.round((highlightedSlot.endTime - START_HOUR) * 2) + 2,
+              gridRowStart: timeToRow(highlightedSlot.startTime),
+              gridRowEnd: Math.max(
+                timeToRow(highlightedSlot.startTime) + 1,
+                timeToRow(highlightedSlot.endTime),
+              ),
             }}
           />
         )}
@@ -491,7 +486,7 @@ export default TimetableGrid;
 const GridContainer = styled.div<{ $rowCount: number; $dayCount: number }>`
   display: grid;
   grid-template-columns: 24px repeat(${({ $dayCount }) => $dayCount}, minmax(0, 1fr));
-  grid-template-rows: 24px repeat(${({ $rowCount }) => $rowCount}, 25px);
+  grid-template-rows: 24px repeat(${({ $rowCount }) => $rowCount}, ${ROW_HEIGHT_PX}px);
   border: 1px solid var(--border-strong);
   border-radius: 16px;
   background-color: var(--bg-base);

--- a/src/types/timetableWizard.ts
+++ b/src/types/timetableWizard.ts
@@ -1,6 +1,7 @@
 import type { Term } from "@/types/timetables";
 
-// TimetableGrid 규약과 동일: day 0=월 ~ 4=금, startTime/endTime은 9~21 사이 0.5 단위 시간값
+// TimetableGrid 규약과 동일: day 0=월 ~ 4=금, startTime/endTime은 9~21 사이 시간값
+// (10.75 = 10:45). 45분 수업도 있어 30분 배수라는 보장은 없다.
 export interface WizardCourseMeeting {
   day: number;
   startTime: number;

--- a/src/utils/timetableWizardGenerator.ts
+++ b/src/utils/timetableWizardGenerator.ts
@@ -27,16 +27,37 @@ const PERIOD_HOURS = 1.5;
 // 위시리스트가 커도 조합 폭발을 막는 안전장치 (정상적인 6개 이하 위시리스트에서는 절대 도달하지 않음)
 const MAX_CANDIDATES = 5000;
 
-const meetingToSlots = (m: WizardCourseMeeting): string[] => {
+const EPSILON = 1e-6;
+
+// 두 수업 시간이 실제로 겹치는지(같은 요일 + 구간 교차). 예전에는 시작 시각부터 30분씩
+// 끊은 슬롯 문자열 집합으로 판정했는데, 45분 수업처럼 30분 배수가 아닌 시간이 오면
+// 슬롯 격자가 서로 어긋나 겹침을 통째로 놓쳤다(예: 09:00~09:45와 09:45~11:00).
+const meetingsOverlap = (a: WizardCourseMeeting, b: WizardCourseMeeting): boolean =>
+  a.day === b.day &&
+  a.startTime < b.endTime - EPSILON &&
+  b.startTime < a.endTime - EPSILON;
+
+const overlapsAny = (
+  course: WizardCourseOption,
+  meetings: WizardCourseMeeting[],
+): boolean => course.meetings.some((m) => meetings.some((o) => meetingsOverlap(m, o)));
+
+// 제외 시간대만은 사용자가 30분 격자(TimetableGrid 선택 칸)에서 고른 값이라, 수업이
+// 조금이라도 걸치는 30분 칸을 전부 구해서 비교한다(시작은 내림, 끝은 걸친 칸까지).
+const meetingToGridSlots = (m: WizardCourseMeeting): string[] => {
   const slots: string[] = [];
-  for (let t = m.startTime; t < m.endTime - 1e-6; t += SLOT_STEP) {
+  for (
+    let t = Math.floor(m.startTime / SLOT_STEP) * SLOT_STEP;
+    t < m.endTime - EPSILON;
+    t += SLOT_STEP
+  ) {
     slots.push(`${m.day}-${t}`);
   }
   return slots;
 };
 
-const courseSlots = (course: WizardCourseOption): string[] =>
-  course.meetings.flatMap(meetingToSlots);
+const courseGridSlots = (course: WizardCourseOption): string[] =>
+  course.meetings.flatMap(meetingToGridSlots);
 
 interface WishlistGroup {
   courseId: number;
@@ -89,10 +110,10 @@ interface HardCheckContext {
 // 이 강의 하나가 이미 배치된 슬롯과 무관하게 그 자체로 하드 조건을 위반하는지(요일 지정공강만
 // 하드). 오전/야간 회피(C-03/C-04)는 참고 아티팩트에서도 score()에만 반영되는 소프트
 // 조건이라 여기서는 검사하지 않는다 - buildReasons()에서 점수로만 반영한다.
-// courseSlots까지 계산해 배치된 슬롯·제외 슬롯과 겹치는지도 함께 확인한다.
+// 이미 배치된 수업 시간·제외 시간대와 겹치는지도 함께 확인한다.
 const violatesHardConstraints = (
   course: WizardCourseOption,
-  occupiedSlots: Set<string>,
+  occupiedMeetings: WizardCourseMeeting[],
   ctx: HardCheckContext,
 ): boolean => {
   if (!ctx.flags.ignoreExcludedCourses && ctx.excludedSubjectNumberSet.has(course.subjectNumber)) {
@@ -110,10 +131,21 @@ const violatesHardConstraints = (
     }
   }
 
-  const slots = courseSlots(course);
-  if (new Set(slots).size !== slots.length) return true; // 데이터 이상(자체 시간 중복) 방어
-  if (slots.some((s) => occupiedSlots.has(s))) return true; // 이미 배치된 강의와 겹침
-  if (!ctx.flags.ignoreExcludedSlots && slots.some((s) => ctx.excludedSlotSet.has(s))) return true;
+  // 데이터 이상(자체 시간 중복) 방어
+  const own = course.meetings;
+  for (let i = 0; i < own.length; i += 1) {
+    for (let j = i + 1; j < own.length; j += 1) {
+      if (meetingsOverlap(own[i], own[j])) return true;
+    }
+  }
+
+  if (overlapsAny(course, occupiedMeetings)) return true; // 이미 배치된 강의와 겹침
+  if (
+    !ctx.flags.ignoreExcludedSlots &&
+    courseGridSlots(course).some((s) => ctx.excludedSlotSet.has(s))
+  ) {
+    return true;
+  }
 
   return false;
 };
@@ -126,7 +158,11 @@ const searchCombinations = (
 ): WizardCourseOption[][] => {
   const results: WizardCourseOption[][] = [];
 
-  const backtrack = (index: number, chosen: WizardCourseOption[], occupiedSlots: Set<string>) => {
+  const backtrack = (
+    index: number,
+    chosen: WizardCourseOption[],
+    occupiedMeetings: WizardCourseMeeting[],
+  ) => {
     if (results.length >= MAX_CANDIDATES) return;
     if (index === groups.length) {
       results.push(chosen);
@@ -135,18 +171,16 @@ const searchCombinations = (
 
     const group = groups[index];
     for (const option of group.options) {
-      if (violatesHardConstraints(option, occupiedSlots, ctx)) continue;
-      const nextOccupied = new Set(occupiedSlots);
-      courseSlots(option).forEach((s) => nextOccupied.add(s));
-      backtrack(index + 1, [...chosen, option], nextOccupied);
+      if (violatesHardConstraints(option, occupiedMeetings, ctx)) continue;
+      backtrack(index + 1, [...chosen, option], [...occupiedMeetings, ...option.meetings]);
     }
 
     if (!group.required) {
-      backtrack(index + 1, chosen, occupiedSlots); // 선택 과목은 이번 조합에서 통째로 제외 가능
+      backtrack(index + 1, chosen, occupiedMeetings); // 선택 과목은 이번 조합에서 통째로 제외 가능
     }
   };
 
-  backtrack(0, [], new Set());
+  backtrack(0, [], []);
   return results;
 };
 


### PR DESCRIPTION
Closes #237

## 문제

45분짜리 수업이 실제로 있는데 `TimetableGrid`의 행 단위가 30분이라, 블록 위치를 30분 격자로 반올림해서 실제와 다른 시간에 그렸다. 헤드리스 브라우저로 수정 전 렌더링을 재보면:

| 수업 | 실제 | 수정 전 렌더링 |
|---|---|---|
| 09:00~09:45 | 45분 | 09:00~10:00 (60분) |
| 09:45~10:30 | 45분 | **10:00**~10:30 (30분) |
| 09:15~10:30 | 75분 | 09:30~10:30 (60분) |

## 변경

**1. 그리드 행 단위 30분 → 5분** (`TimetableGrid.tsx`)

45·75분 등 30분 배수가 아닌 수업도 정확한 위치/높이로 그린다. 30분 칸 하나가 6행을 덮는 구조라 **눈에 보이는 칸과 드래그 선택 단위는 30분 그대로**다 — 선택 슬롯 문자열(`day-hour`, 0.5 단위)이 강의 검색 필터·마법사 제외조건과 공유하는 규약이라 여기를 잘게 쪼개면 안 되고, UX상으로도 5분 칸을 드래그로 고르게 할 이유가 없다. 30분 칸 높이 25px도 유지해서 전체 시간표 크기는 그대로다.

정시에 끝나지 않는 수업(예: 18:45)이 마지막 행 밖으로 넘치던 문제도 함께 고쳤다(끝 시각 올림).

**2. 마법사 조합 생성기의 시간 겹침 판정** (`timetableWizardGenerator.ts`)

같은 30분 격자 가정이 여기에도 있었다. 시작 시각부터 30분씩 끊은 슬롯 문자열로 겹침을 봤는데, 30분 배수가 아닌 시간이 오면 두 수업의 격자가 서로 어긋나 겹침을 통째로 놓쳤다. 구간 교차 비교로 바꿨다. 사용자가 30분 격자에서 고르는 **제외 시간대만** 걸치는 칸으로 내림/올림해 비교한다.

## 검증

`vite dev` + 헤드리스 크로미움으로 더미 시간표를 실제 렌더링해 블록의 픽셀 위치를 측정했다. 45분 3연속(09:00/09:45/10:30 시작), 75분, 09:15·11:45·14:05 시작, 18:15~19:00 야간 수업 모두 시간에 정확히 대응하는 위치·높이로 그려지고, 기존 30분 배수 수업(60·90분)도 회귀 없음. 선택 모드의 30분 칸도 그대로 유지되는 것을 확인했다.

생성기는 아래 6개 케이스를 dev 서버에서 실제로 돌려 수정 전/후를 비교했다:

| 케이스 | 기대 | 수정 전 | 수정 후 |
|---|---|---|---|
| 09:00-09:45 vs 09:30-10:15 (겹침) | 후보 0 | 0 | 0 |
| 09:00-09:45 vs 09:45-10:30 (연속) | 후보 1 | 1 | 1 |
| 09:00-10:30 vs 10:00-11:30 (겹침) | 후보 0 | 0 | 0 |
| 09:45-10:30 + 제외 09:30칸 | 후보 0 | **1** ❌ | 0 |
| 09:45-10:30 + 제외 11:00칸 | 후보 1 | 1 | 1 |
| 09:00-09:45 vs 09:15-10:00 (격자 어긋난 겹침) | 후보 0 | **1** ❌ | 0 |

`npm run build`(tsc 포함) 통과. `npm run lint`는 이 브랜치와 무관하게 원래 깨져 있다(ESLint 9인데 flat config 파일이 없음).

## 참고

- 검증용 임시 엔트리(`grid-sandbox.html`, `src/devGridSandbox.tsx`, `src/devWizardCheck.ts`)는 커밋에 포함하지 않았다.
- 5분 행이 4.1667px라 하루 전체(9시간)에서 서브픽셀 누적 오차가 ~1px 생기지만, 모든 블록이 같은 그리드에서 나오므로 블록끼리는 정확히 정렬된다.

https://claude.ai/code/session_01YRppGrYENAPSYgMr6iMjPj