### PR TITLE
✨ feat: 친구추가 URL/QR 화면 및 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "lucide-react": "^0.542.0",
         "mixpanel-browser": "^2.78.0",
         "motion": "^12.23.26",
+        "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
@@ -102,6 +103,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -429,6 +431,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
       "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -1113,6 +1116,7 @@
       "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.18.tgz",
       "integrity": "sha512-cD7XtZIZZ87Cg2+itnpsONCsZ89VIfLLDZ22pQX4IQVWlpYUB3bcCf878DhWkqyEen6dhi5ePtBoqYgm5K+0fQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "preact": "~10.12.1"
       }
@@ -1739,6 +1743,7 @@
       "resolved": "https://registry.npmjs.org/@mixpanel/rrweb/-/rrweb-2.0.0-alpha.18.4.tgz",
       "integrity": "sha512-ICpEYDFEEiCoUuQg+de3VvQCsolF4lNHfEM9DBp5Pwuc7EgXqwWV4wUpiRF/NbhoKk+82X1Qe+oqqlKJb/CGFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mixpanel/rrdom": "^2.0.0-alpha.18",
         "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18",
@@ -1779,7 +1784,8 @@
       "version": "2.0.0-alpha.18.4",
       "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-utils/-/rrweb-utils-2.0.0-alpha.18.4.tgz",
       "integrity": "sha512-c3nUbQl19kxHjf8nowFMeXlJw0ZqLesIVBb9t4g1nC4WtaNEPkFotWRdGt5V2cJNQ+aY38/v2uYb8Ren4IcdSQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
@@ -2811,6 +2817,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3094,6 +3101,7 @@
       "integrity": "sha512-sr4Xz74KOUeYadexo1r8imhRtlVXcs+j3XK3TcoiYk7B1t3YRVJgtaD3cwX73NYb71pmVuMLNRhJ9XKdoDB74g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3110,6 +3118,7 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3121,6 +3130,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3179,6 +3189,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -3422,6 +3433,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3650,6 +3662,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -4235,7 +4248,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-autoplay": {
       "version": "8.6.0",
@@ -4417,6 +4431,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5682,6 +5697,7 @@
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.26.tgz",
       "integrity": "sha512-Ll8XhVxY8LXMVYTCfme27WH2GjBrCIzY4+ndr5QKxsK+YwCtOi2B/oBi5jcIbik5doXuWT/4KKDOVAZJkeY5VQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "framer-motion": "^12.23.26",
         "tslib": "^2.4.0"
@@ -6153,6 +6169,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -6180,6 +6205,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6192,6 +6218,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6256,7 +6283,8 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-modal-sheet": {
       "version": "5.6.0",
@@ -6279,6 +6307,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6501,7 +6530,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -6608,7 +6636,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6647,6 +6676,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7201,7 +7231,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7222,6 +7253,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7442,6 +7474,7 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -7649,6 +7682,7 @@
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
       "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"
@@ -7679,6 +7713,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lucide-react": "^0.542.0",
     "mixpanel-browser": "^2.78.0",
     "motion": "^12.23.26",
+    "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",

--- a/src/apis/courseOfferings.ts
+++ b/src/apis/courseOfferings.ts
@@ -7,8 +7,6 @@ import { MOCK_COURSES, MOCK_COURSE_OFFERINGS } from "@/mocks/mockTimetableWizard
 
 // 서버 명세: 페이지당 크기는 50으로 고정됩니다.
 const PAGE_SIZE = 50;
-// 무한 루프 방지용 안전장치
-const MAX_PAGES = 50;
 
 /**
  * 학기별 개설 강의 목록 조회 (페이지 단위)

--- a/src/apis/friends.ts
+++ b/src/apis/friends.ts
@@ -1,5 +1,8 @@
 import tokenInstance from "./tokenInstance";
+import axiosInstance from "./axiosInstance";
 import {
+  FriendInviteCodeResponseDto,
+  FriendInvitePreviewResponseDto,
   FriendRequestDto,
   FriendResponseDto,
   MemberLocationRequestDto,
@@ -10,6 +13,12 @@ import { ApiResponse } from "@/types/common";
 import { MemberProfileResponseDto } from "@/types/members";
 import { isMockApiEnabled, mockDelay } from "@/mocks/mockFlag";
 import { getMockNearbyFriends } from "@/mocks/mockNearbyFriends";
+import {
+  getMockAcceptedFriend,
+  getMockInviteCode,
+  getMockInvitePreview,
+  getMockRefreshedInviteCode,
+} from "@/mocks/mockFriendInvite";
 
 /**
  * 친구 요청 보내기
@@ -181,6 +190,91 @@ export const getNearbyFriends = async (
   const response = await tokenInstance.get<ApiResponse<NearbyMemberResponseDto[]>>(
     "/api/friends/nearby",
     { params: { latitude, longitude, radiusMeters } },
+  );
+  return response.data;
+};
+
+/**
+ * 내 친구추가 링크(초대 코드) 조회
+ * 유효한 코드가 있으면 그대로, 없으면 서버가 새로 발급해 돌려준다.
+ */
+export const getMyInviteCode = async (): Promise<
+  ApiResponse<FriendInviteCodeResponseDto>
+> => {
+  if (isMockApiEnabled()) {
+    await mockDelay();
+    return {
+      result: [],
+      data: getMockInviteCode(),
+      msg: "친구추가 링크 조회 성공",
+    };
+  }
+  const response = await tokenInstance.get<
+    ApiResponse<FriendInviteCodeResponseDto>
+  >("/api/friends/invite-code");
+  return response.data;
+};
+
+/**
+ * 내 친구추가 링크 재발급
+ * 기존 링크는 즉시 무효화된다. 링크가 유출됐을 때 끊는 유일한 수단.
+ */
+export const refreshMyInviteCode = async (): Promise<
+  ApiResponse<FriendInviteCodeResponseDto>
+> => {
+  if (isMockApiEnabled()) {
+    await mockDelay();
+    return {
+      result: [],
+      data: getMockRefreshedInviteCode(),
+      msg: "친구추가 링크 재발급 성공",
+    };
+  }
+  const response = await tokenInstance.post<
+    ApiResponse<FriendInviteCodeResponseDto>
+  >("/api/friends/invite-code/refresh");
+  return response.data;
+};
+
+/**
+ * 친구추가 링크 미리보기 (링크 주인이 누구인지)
+ *
+ * 비로그인 상태에서도 열람 가능한 유일한 친구 API다. 토큰 인터셉터가 붙은
+ * tokenInstance를 쓰면 미로그인 시 불필요한 리프레시 시도가 일어나므로 평문 인스턴스를 쓴다.
+ */
+export const getInvitePreview = async (
+  code: string,
+): Promise<ApiResponse<FriendInvitePreviewResponseDto>> => {
+  if (isMockApiEnabled()) {
+    await mockDelay();
+    return {
+      result: [],
+      data: getMockInvitePreview(),
+      msg: "친구추가 링크 조회 성공",
+    };
+  }
+  const response = await axiosInstance.get<
+    ApiResponse<FriendInvitePreviewResponseDto>
+  >(`/api/friends/invite/${encodeURIComponent(code)}`);
+  return response.data;
+};
+
+/**
+ * 친구추가 링크 수락 — 링크 주인과 즉시 친구가 된다.
+ */
+export const acceptInvite = async (
+  code: string,
+): Promise<ApiResponse<FriendResponseDto>> => {
+  if (isMockApiEnabled()) {
+    await mockDelay();
+    return {
+      result: [],
+      data: getMockAcceptedFriend(),
+      msg: "친구추가 성공",
+    };
+  }
+  const response = await tokenInstance.post<ApiResponse<FriendResponseDto>>(
+    `/api/friends/invite/${encodeURIComponent(code)}/accept`,
   );
   return response.data;
 };

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -31,6 +31,10 @@ export const ROUTES = {
   // 친구
   FRIEND: {
     LIST: "/friend/list",
+    QR: "/friend/qr",
+    // 초대 링크. functions/_middleware.ts 의 OG 태그 주입 경로와 맞춰져 있다.
+    INVITE: (code: string) => `/friend/invite/${code}`,
+    INVITE_PATTERN: "/friend/invite/:code",
   },
 
   //전화번호부

--- a/src/mocks/mockFriendInvite.ts
+++ b/src/mocks/mockFriendInvite.ts
@@ -1,0 +1,42 @@
+import type {
+  FriendInviteCodeResponseDto,
+  FriendInvitePreviewResponseDto,
+  FriendResponseDto,
+} from "@/types/friends";
+
+/**
+ * 친구추가 URL/QR 목 데이터.
+ * 서버 API(inu-appcenter/inu-portal-server#330) 배포 전에도 화면을 확인할 수 있게 한다.
+ * `npm run dev:mock` 에서만 쓰인다.
+ */
+
+const MOCK_CODE = "mockInviteCode000000aB";
+
+export const getMockInviteCode = (): FriendInviteCodeResponseDto => ({
+  code: MOCK_CODE,
+  url: `https://intip.inuappcenter.kr/friend/invite/${MOCK_CODE}`,
+});
+
+/** 재발급을 눌렀을 때 코드가 실제로 바뀌는 걸 확인할 수 있도록 매번 다른 값을 만든다. */
+export const getMockRefreshedInviteCode = (): FriendInviteCodeResponseDto => {
+  const code = `mock${Math.random().toString(36).slice(2, 12).padEnd(10, "0")}${Date.now()
+    .toString(36)
+    .slice(-8)}`;
+  return {
+    code,
+    url: `https://intip.inuappcenter.kr/friend/invite/${code}`,
+  };
+};
+
+export const getMockInvitePreview = (): FriendInvitePreviewResponseDto => ({
+  nickname: "인천대사자",
+  studentId: "2021****34",
+  fireId: 3,
+});
+
+export const getMockAcceptedFriend = (): FriendResponseDto => ({
+  friendId: 9001,
+  nickname: "인천대사자",
+  studentId: "2021****34",
+  fireId: 3,
+});

--- a/src/pages/mobile/MobileFriendInvitePage.tsx
+++ b/src/pages/mobile/MobileFriendInvitePage.tsx
@@ -1,0 +1,342 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import styled from "styled-components";
+import { Check, LinkIcon, User, UserPlus } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useHeader } from "@/context/HeaderContext";
+import { MOBILE_PAGE_GUTTER } from "@/styles/responsive";
+import { acceptInvite, getInvitePreview } from "@/apis/friends";
+import { ROUTES } from "@/constants/routes";
+import useUserStore from "@/stores/useUserStore";
+import {
+  DEFAULT_PROFILE_IMAGE_ID,
+  normalizeProfileImageId,
+} from "@/utils/userInfo";
+
+/** 로그인 왕복 후 "친구 되기"를 다시 누르지 않아도 되게 하는 표식. */
+const AUTO_ACCEPT_STORAGE_KEY = "__intipPendingFriendInviteCode";
+
+function getStoredAccessToken() {
+  const storedTokenInfo = localStorage.getItem("tokenInfo");
+  if (!storedTokenInfo) return "";
+  try {
+    return JSON.parse(storedTokenInfo)?.accessToken ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * 친구추가 링크 수락 화면.
+ *
+ * 링크 주인은 링크를 만든 시점에 이미 동의한 것으로 보므로, 수락하면 승인 절차 없이
+ * 곧바로 친구가 된다. 미리보기는 비로그인 상태에서도 열리고, 수락 시점에만 로그인을 요구한다.
+ */
+export default function MobileFriendInvitePage() {
+  const { code = "" } = useParams<{ code: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const queryClient = useQueryClient();
+  const { tokenInfo } = useUserStore();
+  const [isAccepted, setIsAccepted] = useState(false);
+  const hasAutoAcceptedRef = useRef(false);
+
+  const isLoggedIn =
+    Boolean(tokenInfo.accessToken) || Boolean(getStoredAccessToken());
+
+  useHeader({
+    title: "친구 추가",
+    hasback: true,
+    backPath: ROUTES.FRIEND.LIST,
+  });
+
+  const {
+    data,
+    isLoading,
+    error: previewError,
+  } = useQuery({
+    queryKey: ["friendInvitePreview", code],
+    queryFn: () => getInvitePreview(code),
+    enabled: Boolean(code),
+    retry: false,
+    staleTime: Infinity,
+  });
+
+  const owner = data?.data;
+
+  const acceptMutation = useMutation({
+    mutationFn: () => acceptInvite(code),
+    onSuccess: () => {
+      setIsAccepted(true);
+      queryClient.invalidateQueries({ queryKey: ["friends"] });
+      queryClient.invalidateQueries({ queryKey: ["pendingFriends"] });
+    },
+    onError: (error: any) => {
+      alert(error.response?.data?.msg || "친구 추가에 실패했어요.");
+    },
+  });
+
+  const handleAccept = useCallback(() => {
+    if (!isLoggedIn) {
+      // 로그인 페이지를 다녀온 뒤 이 화면으로 돌아와 자동으로 수락되게 표식을 남긴다.
+      localStorage.setItem(AUTO_ACCEPT_STORAGE_KEY, code);
+      const redirectPath = `${location.pathname}${location.search}`;
+      navigate(`${ROUTES.LOGIN}?redirect=${encodeURIComponent(redirectPath)}`);
+      return;
+    }
+    acceptMutation.mutate();
+  }, [isLoggedIn, code, location.pathname, location.search, navigate, acceptMutation]);
+
+  // 로그인 왕복 복귀 시 1회만 자동 수락한다.
+  useEffect(() => {
+    if (hasAutoAcceptedRef.current) return;
+    if (!isLoggedIn || !owner || isAccepted) return;
+    if (localStorage.getItem(AUTO_ACCEPT_STORAGE_KEY) !== code) return;
+
+    hasAutoAcceptedRef.current = true;
+    localStorage.removeItem(AUTO_ACCEPT_STORAGE_KEY);
+    acceptMutation.mutate();
+  }, [isLoggedIn, owner, isAccepted, code, acceptMutation]);
+
+  if (isLoading) {
+    return (
+      <PageWrapper>
+        <StatusBlock>
+          <IconWrapper>
+            <LinkIcon size={24} strokeWidth={2.2} />
+          </IconWrapper>
+          <Title>링크를 확인하는 중이에요</Title>
+        </StatusBlock>
+      </PageWrapper>
+    );
+  }
+
+  if (previewError || !owner) {
+    return (
+      <PageWrapper>
+        <StatusBlock>
+          <IconWrapper $tone="muted">
+            <LinkIcon size={24} strokeWidth={2.2} />
+          </IconWrapper>
+          <Title>유효하지 않은 링크예요</Title>
+          <Description>
+            링크가 만료됐거나 새 링크로 바뀌었을 수 있어요.
+            <br />
+            상대방에게 링크를 다시 받아주세요.
+          </Description>
+          <PrimaryButton type="button" onClick={() => navigate(ROUTES.HOME)}>
+            홈으로
+          </PrimaryButton>
+        </StatusBlock>
+      </PageWrapper>
+    );
+  }
+
+  const safeFireId = normalizeProfileImageId(
+    owner.fireId,
+    DEFAULT_PROFILE_IMAGE_ID,
+  );
+
+  return (
+    <PageWrapper>
+      <StatusBlock>
+        <ProfileArea>
+          <ProfileImage
+            src={`https://portal.inuappcenter.kr/images/profile/${safeFireId}`}
+            alt=""
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = "none";
+            }}
+          />
+          <DefaultIconArea>
+            <User size={32} color="#D6D1D5" />
+          </DefaultIconArea>
+          {isAccepted && (
+            <AcceptedBadge>
+              <Check size={14} strokeWidth={3} />
+            </AcceptedBadge>
+          )}
+        </ProfileArea>
+
+        <Nickname>{owner.nickname}</Nickname>
+        <ProfileSubtitle>{owner.studentId}</ProfileSubtitle>
+
+        {isAccepted ? (
+          <>
+            <Title>이제 친구예요</Title>
+            <Description>
+              친구 목록에서 시간표를 비교하고 대화를 시작해보세요.
+            </Description>
+            <PrimaryButton
+              type="button"
+              onClick={() => navigate(ROUTES.FRIEND.LIST, { replace: true })}
+            >
+              친구 목록 보기
+            </PrimaryButton>
+          </>
+        ) : (
+          <>
+            <Title>{owner.nickname}님이 친구를 신청했어요</Title>
+            <Description>
+              수락하면 바로 친구가 돼요.
+              {!isLoggedIn && (
+                <>
+                  <br />
+                  INTIP에 로그인한 뒤 이어서 진행돼요.
+                </>
+              )}
+            </Description>
+            <PrimaryButton
+              type="button"
+              onClick={handleAccept}
+              disabled={acceptMutation.isPending}
+            >
+              <UserPlus size={18} />
+              {acceptMutation.isPending
+                ? "추가하는 중…"
+                : isLoggedIn
+                  ? "친구 되기"
+                  : "로그인하고 친구 되기"}
+            </PrimaryButton>
+          </>
+        )}
+      </StatusBlock>
+    </PageWrapper>
+  );
+}
+
+const PageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 24px ${MOBILE_PAGE_GUTTER} 40px;
+`;
+
+const StatusBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 0 8px;
+`;
+
+const IconWrapper = styled.div<{ $tone?: "brand" | "muted" }>`
+  width: 52px;
+  height: 52px;
+  border-radius: 999px;
+  background: ${({ $tone }) =>
+    $tone === "muted"
+      ? "var(--bg-muted, #f1f3f5)"
+      : "var(--bg-brand, #eff6ff)"};
+  color: ${({ $tone }) =>
+    $tone === "muted"
+      ? "var(--text-tertiary, #8b95a1)"
+      : "var(--text-brand, #0061ff)"};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 4px auto 12px;
+`;
+
+const ProfileArea = styled.div`
+  position: relative;
+  width: 80px;
+  height: 80px;
+  border-radius: 999px;
+  background: var(--bg-muted, #f1f3f5);
+  margin-bottom: 12px;
+`;
+
+const DefaultIconArea = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ProfileImage = styled.img`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 999px;
+  object-fit: cover;
+  z-index: 1;
+`;
+
+const AcceptedBadge = styled.div`
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+  z-index: 2;
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  border: 2px solid var(--bg-base, #ffffff);
+  background: var(--interactive-primary, #3b82f6);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Nickname = styled.div`
+  font-family: Pretendard;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary, #333d4b);
+`;
+
+const ProfileSubtitle = styled.div`
+  margin-top: 2px;
+  margin-bottom: 20px;
+  font-family: Pretendard;
+  font-size: 13px;
+  color: var(--text-tertiary, #8b95a1);
+`;
+
+const Title = styled.h2`
+  margin: 0 0 8px;
+  font-family: Pretendard;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary, #333d4b);
+  text-align: center;
+`;
+
+const Description = styled.p`
+  margin: 0 0 24px;
+  font-family: Pretendard;
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--text-tertiary, #8b95a1);
+  text-align: center;
+`;
+
+const PrimaryButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  height: 52px;
+  border: none;
+  border-radius: 999px;
+  background-color: var(--interactive-primary, #3b82f6);
+  color: #ffffff;
+  font-family: Pretendard;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+
+  &:active:not(:disabled) {
+    background-color: var(--interactive-primary-pressed, #2563eb);
+    transform: scale(0.98);
+  }
+
+  &:disabled {
+    background-color: var(--bg-muted, #f1f3f5);
+    color: var(--text-tertiary, #8b95a1);
+    cursor: not-allowed;
+  }
+`;

--- a/src/pages/mobile/MobileFriendListPage.tsx
+++ b/src/pages/mobile/MobileFriendListPage.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/utils/userInfo";
 import FloatingSearchBar from "@/components/mobile/common/FloatingSearchBar";
 import Ripple from "@/components/common/Ripple";
-import { ArrowDownAZ, ArrowUpZA, Search, MapPin } from "lucide-react";
+import { ArrowDownAZ, ArrowUpZA, Search, MapPin, QrCode } from "lucide-react";
 import NearbyFriendInfoSheet from "@/components/mobile/social/NearbyFriendInfoSheet";
 
 // --- SVG Icons ---
@@ -740,6 +740,18 @@ export default function MobileFriendListPage() {
         {/* Plus button - scale out when selection mode is active */}
         <PlusButtonWrapper $visible={!isSelectionMode && !isSearchActive}>
           <SpeedDialList $open={isAddMenuOpen}>
+            <SpeedDialItem
+              $open={isAddMenuOpen}
+              $order={2}
+              onClick={() => {
+                closeAddMenu(() => navigate(ROUTES.FRIEND.QR));
+              }}
+            >
+              <SpeedDialLabel>내 QR 코드</SpeedDialLabel>
+              <SpeedDialButton as="span">
+                <QrCode size={20} />
+              </SpeedDialButton>
+            </SpeedDialItem>
             <SpeedDialItem
               $open={isAddMenuOpen}
               $order={1}

--- a/src/pages/mobile/MobileFriendQrPage.tsx
+++ b/src/pages/mobile/MobileFriendQrPage.tsx
@@ -1,0 +1,397 @@
+import { useCallback, useMemo, useState } from "react";
+import styled from "styled-components";
+import { QRCodeSVG } from "qrcode.react";
+import { Check, Copy, RefreshCw, Share2, User } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useHeader } from "@/context/HeaderContext";
+import { MOBILE_PAGE_GUTTER } from "@/styles/responsive";
+import { getMyInviteCode, refreshMyInviteCode } from "@/apis/friends";
+import { ROUTES } from "@/constants/routes";
+import useUserStore from "@/stores/useUserStore";
+import {
+  DEFAULT_PROFILE_IMAGE_ID,
+  normalizeProfileImageId,
+} from "@/utils/userInfo";
+
+/**
+ * 내 친구추가 QR / 링크.
+ *
+ * 서버가 돌려주는 url은 운영 도메인 고정이라, 실제로 공유하는 링크는 현재 origin 기준으로
+ * 다시 조립한다. 그래야 intip-test.pages.dev 에서 만든 QR이 테스트 환경으로 떨어진다.
+ */
+export default function MobileFriendQrPage() {
+  const queryClient = useQueryClient();
+  const { userInfo } = useUserStore();
+  const [isCopied, setIsCopied] = useState(false);
+
+  useHeader({
+    title: "친구추가 QR",
+    hasback: true,
+  });
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["myInviteCode"],
+    queryFn: getMyInviteCode,
+    staleTime: Infinity,
+  });
+
+  const code = data?.data?.code;
+
+  const inviteUrl = useMemo(() => {
+    if (!code) return "";
+    return `${window.location.origin}${ROUTES.FRIEND.INVITE(code)}`;
+  }, [code]);
+
+  const refreshMutation = useMutation({
+    mutationFn: refreshMyInviteCode,
+    onSuccess: (res) => {
+      queryClient.setQueryData(["myInviteCode"], res);
+      setIsCopied(false);
+    },
+    onError: (error: any) => {
+      alert(error.response?.data?.msg || "링크를 새로 만들지 못했어요.");
+    },
+  });
+
+  const handleCopy = useCallback(async () => {
+    if (!inviteUrl) return;
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      setIsCopied(true);
+      window.setTimeout(() => setIsCopied(false), 2000);
+    } catch {
+      alert("링크를 복사하지 못했어요. 주소를 길게 눌러 복사해주세요.");
+    }
+  }, [inviteUrl]);
+
+  const handleShare = useCallback(async () => {
+    if (!inviteUrl) return;
+    // WebView·데스크톱 등 공유 시트가 없는 환경에서는 복사로 대체한다.
+    if (!navigator.share) {
+      handleCopy();
+      return;
+    }
+    try {
+      await navigator.share({
+        title: "INTIP 친구추가",
+        text: `${userInfo.nickname}님이 INTIP에서 친구를 신청했어요.`,
+        url: inviteUrl,
+      });
+    } catch {
+      // 사용자가 공유 시트를 닫은 경우 — 아무 것도 하지 않는다.
+    }
+  }, [inviteUrl, userInfo.nickname, handleCopy]);
+
+  const handleRefresh = useCallback(() => {
+    const confirmed = window.confirm(
+      "새 링크를 만들면 지금까지 공유한 링크는 더 이상 쓸 수 없어요. 계속할까요?",
+    );
+    if (confirmed) refreshMutation.mutate();
+  }, [refreshMutation]);
+
+  const safeFireId = normalizeProfileImageId(
+    userInfo.fireId,
+    DEFAULT_PROFILE_IMAGE_ID,
+  );
+
+  return (
+    <PageWrapper>
+      <QrCard>
+        <ProfileArea>
+          <ProfileImage
+            src={`https://portal.inuappcenter.kr/images/profile/${safeFireId}`}
+            alt=""
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = "none";
+            }}
+          />
+          <DefaultIconArea>
+            <User size={22} color="#D6D1D5" />
+          </DefaultIconArea>
+        </ProfileArea>
+
+        <Nickname>{userInfo.nickname || "나"}</Nickname>
+        <ProfileSubtitle>{userInfo.department}</ProfileSubtitle>
+
+        <QrArea>
+          {isLoading || refreshMutation.isPending ? (
+            <QrPlaceholder>불러오는 중…</QrPlaceholder>
+          ) : isError || !inviteUrl ? (
+            <QrPlaceholder>링크를 불러오지 못했어요.</QrPlaceholder>
+          ) : (
+            <QRCodeSVG
+              value={inviteUrl}
+              size={200}
+              level="M"
+              marginSize={0}
+              bgColor="#ffffff"
+              fgColor="#333d4b"
+            />
+          )}
+        </QrArea>
+
+        <QrHint>이 QR을 상대방 카메라로 찍으면 바로 친구가 돼요.</QrHint>
+      </QrCard>
+
+      <LinkRow>
+        <LinkText>{inviteUrl || "링크를 불러오는 중이에요"}</LinkText>
+        <IconButton
+          type="button"
+          onClick={handleCopy}
+          disabled={!inviteUrl}
+          aria-label="링크 복사"
+        >
+          {isCopied ? <Check size={18} /> : <Copy size={18} />}
+        </IconButton>
+      </LinkRow>
+
+      <PrimaryButton type="button" onClick={handleShare} disabled={!inviteUrl}>
+        <Share2 size={18} />
+        링크 공유하기
+      </PrimaryButton>
+
+      <SecondaryButton
+        type="button"
+        onClick={handleRefresh}
+        disabled={refreshMutation.isPending}
+      >
+        <RefreshCw size={16} />
+        링크 새로 만들기
+      </SecondaryButton>
+
+      <NoticeBox>
+        <NoticeTitle>공유하기 전에 확인해주세요</NoticeTitle>
+        <NoticeList>
+          <li>링크를 연 사람은 <strong>수락 없이 바로 내 친구</strong>가 돼요.</li>
+          <li>
+            링크에는 닉네임이나 학번이 담기지 않아요. 무작위로 만든 코드예요.
+          </li>
+          <li>
+            링크가 원치 않는 곳에 퍼졌다면 <strong>링크 새로 만들기</strong>로
+            즉시 끊을 수 있어요.
+          </li>
+        </NoticeList>
+      </NoticeBox>
+    </PageWrapper>
+  );
+}
+
+const PageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 8px ${MOBILE_PAGE_GUTTER} 40px;
+`;
+
+const QrCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 20px 20px;
+  background: var(--bg-base, #ffffff);
+  border: 1px solid var(--border-default, #e5e8eb);
+  border-radius: 20px;
+`;
+
+const ProfileArea = styled.div`
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--bg-muted, #f1f3f5);
+`;
+
+const DefaultIconArea = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ProfileImage = styled.img`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 1;
+`;
+
+const Nickname = styled.div`
+  margin-top: 10px;
+  font-family: Pretendard;
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--text-primary, #333d4b);
+`;
+
+const ProfileSubtitle = styled.div`
+  margin-top: 2px;
+  font-family: Pretendard;
+  font-size: 13px;
+  color: var(--text-tertiary, #8b95a1);
+`;
+
+const QrArea = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 232px;
+  height: 232px;
+  margin-top: 20px;
+  border-radius: 16px;
+  background: #ffffff;
+  border: 1px solid var(--border-subtle, #f1f3f5);
+`;
+
+const QrPlaceholder = styled.div`
+  font-family: Pretendard;
+  font-size: 14px;
+  color: var(--text-tertiary, #8b95a1);
+`;
+
+const QrHint = styled.p`
+  margin: 14px 0 0;
+  font-family: Pretendard;
+  font-size: 13px;
+  line-height: 19px;
+  color: var(--text-tertiary, #8b95a1);
+  text-align: center;
+`;
+
+const LinkRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 12px 12px 16px;
+  background: var(--bg-subtle, #f8f9fb);
+  border-radius: 14px;
+`;
+
+const LinkText = styled.span`
+  flex: 1;
+  min-width: 0;
+  font-family: Pretendard;
+  font-size: 13px;
+  color: var(--text-secondary, #6b7684);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const IconButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid var(--border-default, #e5e8eb);
+  background: var(--bg-base, #ffffff);
+  color: var(--text-secondary, #6b7684);
+  cursor: pointer;
+  outline: none;
+
+  &:active:not(:disabled) {
+    background-color: var(--bg-muted, #f1f3f5);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const PrimaryButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  height: 52px;
+  border: none;
+  border-radius: 999px;
+  background-color: var(--interactive-primary, #3b82f6);
+  color: #ffffff;
+  font-family: Pretendard;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+
+  &:active:not(:disabled) {
+    background-color: var(--interactive-primary-pressed, #2563eb);
+    transform: scale(0.98);
+  }
+
+  &:disabled {
+    background-color: var(--bg-muted, #f1f3f5);
+    color: var(--text-tertiary, #8b95a1);
+    cursor: not-allowed;
+  }
+`;
+
+const SecondaryButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  height: 46px;
+  border: 1px solid var(--border-default, #e5e8eb);
+  border-radius: 999px;
+  background: var(--bg-base, #ffffff);
+  color: var(--text-secondary, #6b7684);
+  font-family: Pretendard;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+
+  &:active:not(:disabled) {
+    background-color: var(--bg-muted, #f1f3f5);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;
+
+const NoticeBox = styled.div`
+  margin-top: 4px;
+  padding: 16px;
+  background: var(--bg-subtle, #f8f9fb);
+  border-radius: 16px;
+`;
+
+const NoticeTitle = styled.div`
+  font-family: Pretendard;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary, #333d4b);
+  margin-bottom: 8px;
+`;
+
+const NoticeList = styled.ul`
+  margin: 0;
+  padding-left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  li {
+    font-family: Pretendard;
+    font-size: 13px;
+    line-height: 19px;
+    color: var(--text-secondary, #6b7684);
+  }
+
+  strong {
+    color: var(--text-primary, #333d4b);
+    font-weight: 600;
+  }
+`;

--- a/src/pages/mobile/MobileTimeTableEditPage.tsx
+++ b/src/pages/mobile/MobileTimeTableEditPage.tsx
@@ -28,80 +28,6 @@ import {
   mapFilterToOfferingFilters,
 } from "@/utils/courseSearchResult";
 
-const COLLEGES = new Set([
-  "경영대학",
-  "공과대학",
-  "교양",
-  "교직",
-  "군사학",
-  "글로벌정경대학",
-  "기타",
-  "단과대구분없음",
-  "단과대구분없음(법학)",
-  "도시과학대학",
-  "사범대학",
-  "사회과학대학",
-  "생명과학기술대학",
-  "예술체육대학",
-  "융합자유전공대학",
-  "인문대학",
-  "일선",
-  "자연과학대학",
-  "정보기술대학",
-]);
-
-const DAY_ENUMS = [
-  "MONDAY",
-  "TUESDAY",
-  "WEDNESDAY",
-  "THURSDAY",
-  "FRIDAY",
-  "SATURDAY",
-  "SUNDAY",
-];
-
-function formatSlotsToMeetings(slots: string[]): string[] {
-  if (!slots || slots.length === 0) return [];
-  const dayGroups: Record<number, number[]> = {};
-  slots.forEach((slot) => {
-    const [dStr, hStr] = slot.split("-");
-    const d = parseInt(dStr, 10);
-    const h = parseFloat(hStr);
-    if (!dayGroups[d]) dayGroups[d] = [];
-    dayGroups[d].push(h);
-  });
-
-  const result: string[] = [];
-  Object.keys(dayGroups).forEach((dKey) => {
-    const d = parseInt(dKey, 10);
-    const dayEnum = DAY_ENUMS[d];
-    if (!dayEnum) return;
-
-    const hours = dayGroups[d].sort((a, b) => a - b);
-    let start = hours[0];
-    let prev = hours[0];
-
-    for (let i = 1; i <= hours.length; i++) {
-      const current = hours[i];
-      if (current === prev + 0.5) {
-        prev = current;
-      } else {
-        const end = prev + 0.5;
-        const formatHour = (val: number): string => {
-          const h = Math.floor(val);
-          const m = Math.round((val - h) * 60);
-          return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
-        };
-        result.push(`${dayEnum}|${formatHour(start)}|${formatHour(end)}`);
-        start = current;
-        prev = current;
-      }
-    }
-  });
-
-  return result;
-}
-
 // --- SVG Icons from Figma ---
 const IconsAddPlus = () => (
   <svg
@@ -247,7 +173,6 @@ const MobileTimeTableEditPage = () => {
   const {
     courseOfferings,
     isLoading: isOfferingsLoading,
-    isFetching: isOfferingsFetching,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,

--- a/src/pages/mobile/timetable/MobileCourseFilterPage.tsx
+++ b/src/pages/mobile/timetable/MobileCourseFilterPage.tsx
@@ -14,7 +14,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { getCourseOfferingsPage } from "@/apis/courseOfferings";
 import { COURSE_OFFERINGS_QUERY_KEY } from "@/hooks/useCourseOfferings";
 import { useTimetableStore } from "@/stores/useTimetableStore";
-import type { CourseOfferingFilters } from "@/types/courseOfferings";
 import { mapFilterToOfferingFilters } from "@/utils/courseSearchResult";
 
 // --- Types & Constants ---

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -54,6 +54,8 @@ import MobileAlertPage from "@/pages/mobile/MobileAlertPage";
 import MobileTimeTablePage from "@/pages/mobile/MobileTimeTablePage";
 import MobileTimeTableEditPage from "@/pages/mobile/MobileTimeTableEditPage";
 import MobileFriendListPage from "@/pages/mobile/MobileFriendListPage";
+import MobileFriendQrPage from "@/pages/mobile/MobileFriendQrPage";
+import MobileFriendInvitePage from "@/pages/mobile/MobileFriendInvitePage";
 import MobileTimeTableComparePage from "@/pages/mobile/timetable/MobileTimeTableComparePage";
 import MobileTimeTableVisibilityPage from "@/pages/mobile/timetable/MobileTimeTableVisibilityPage";
 import MobileCourseAddPage from "@/pages/mobile/timetable/MobileCourseAddPage";
@@ -134,6 +136,11 @@ export const router = createBrowserRouter([
           //시간표
           { path: ROUTES.TIMETABLE.EDIT, element: <MobileTimeTableEditPage /> },
           { path: ROUTES.FRIEND.LIST, element: <MobileFriendListPage /> },
+          { path: ROUTES.FRIEND.QR, element: <MobileFriendQrPage /> },
+          {
+            path: ROUTES.FRIEND.INVITE_PATTERN,
+            element: <MobileFriendInvitePage />,
+          },
           { path: ROUTES.TIMETABLE.COMPARE, element: <MobileTimeTableComparePage /> },
           { path: ROUTES.TIMETABLE.VISIBILITY, element: <MobileTimeTableVisibilityPage /> },
           { path: ROUTES.TIMETABLE.ADD, element: <MobileCourseAddPage /> },

--- a/src/types/friends.ts
+++ b/src/types/friends.ts
@@ -20,6 +20,30 @@ export interface FriendResponseDto {
 }
 
 /**
+ * 내 친구추가 초대 코드
+ * (inu-appcenter/inu-portal-server#330, GET /api/friends/invite-code)
+ *
+ * url은 서버 설정 기준으로 조립된 정규 링크다. 배포 환경(운영 / test.pages.dev)에 따라
+ * 공유 링크가 달라져야 하므로 화면에서는 code로 현재 origin 기준 링크를 직접 만든다.
+ */
+export interface FriendInviteCodeResponseDto {
+  code: string;
+  url: string;
+}
+
+/**
+ * 친구추가 링크 미리보기 - 링크 주인 정보
+ * (inu-appcenter/inu-portal-server#330, GET /api/friends/invite/{code})
+ *
+ * 비로그인 상태에서도 조회되는 응답이라 학번은 마스킹된 값만 담긴다.
+ */
+export interface FriendInvitePreviewResponseDto {
+  nickname: string;
+  studentId: string;
+  fireId: number;
+}
+
+/**
  * 주변 친구 찾기 - 위치 노출 on/off 요청 DTO
  * (inu-appcenter/inu-portal-server#302, PATCH /api/members/nearby-visibility)
  */


### PR DESCRIPTION
## 📄 설명

닉네임 검색 외에 **URL/QR**로도 친구를 추가할 수 있게 합니다. 서버는 별도 PR(inu-appcenter/inu-portal-server#330)에서 작업했습니다.

`feat/near-friends`(주변 친구 찾기, FAB 스피드다이얼)를 base로 잡고 그 위에 "내 QR 코드" 항목을 추가했습니다.

### 새 화면

| 경로 | 설명 |
| --- | --- |
| `/friend/qr` | 내 QR/링크 표시, 복사, 공유, 재발급 |
| `/friend/invite/:code` | 링크 수락 화면. 비로그인 상태에서도 미리보기 가능 |

### 설계 메모

- **즉시 ACCEPTED**: 서버가 그렇게 동작하므로(#330), "친구 되기"를 누르면 승인 절차 없이 바로 친구가 됩니다.
- **비로그인 처리**: 미리보기(`GET /api/friends/invite/{code}`)는 로그인 없이도 열립니다. "친구 되기"를 누른 시점에만 로그인을 요구하고, `?redirect=` 로 로그인 페이지를 왕복한 뒤 `localStorage` 표식으로 원래 화면에 돌아와 자동으로 한 번 수락합니다.
- **도메인 분기**: 서버 응답에는 운영 도메인 고정 `url` 필드가 있지만, 화면에서는 쓰지 않고 `code` 로 `window.location.origin` 기준 링크를 직접 조립합니다. 운영/`intip-test.pages.dev` 각자 환경에 맞는 QR·링크가 나옵니다.
- **공유**: `navigator.share` 있으면 공유 시트, 없으면(데스크톱/WebView 구버전) 클립보드 복사로 폴백합니다.
- **재발급**: 링크가 유출됐을 때 끊는 유일한 수단이라 confirm 확인 후 진행합니다.
- **디자인**: 별도 Figma 시안이 없어 `NearbyFriendInfoSheet` / 친구 목록 화면의 토큰(Pretendard, pill 버튼, 카드 20px, `--bg-subtle` 등)을 그대로 따랐습니다.
- **QR 스캔(읽는 쪽)은 범위 밖**입니다. 상대는 휴대폰 기본 카메라로 URL을 인식해 들어옵니다.

### 검증

- `dev:mock` + Playwright로 실제 렌더 확인 (FAB → 내 QR 코드 → 링크 열람 → 수락 완료 플로우)
- `tsc --noEmit`: 이번 변경 파일 기준 에러 없음 (리포에 기존 `noUnusedLocals` 에러 5건이 있으나 이 PR과 무관한 다른 브랜치 소스)
- `vite build` 성공
- `qrcode.react` 추가 후 `npm ls react-native react-native-webview` 빈 트리 확인 (CLAUDE.md 제약 준수)

## 🤔 추후 작업 사항

- 서버 PR(#330)이 dev에 머지되고 배포된 뒤 실제 API로 재검증 필요 (그 전까지는 `dev:mock`으로만 확인 가능)
- 유효하지 않은 링크(만료/재발급된 코드) 화면은 코드 경로만 있고 실제 렌더 스크린샷은 아직 못 찍었습니다
- QR 스캔 기능은 별도 논의 필요 (intip-bridge 신규 이벤트 + 네이티브 카메라 권한 작업 필요)

https://claude.ai/code/session_014nmu2j1MTFEU4jRKNAYQHB
