### PR TITLE
feat: 이러닝·온라인 과목만 보기 필터 추가 (#253)

### DIFF
--- a/src/apis/courseOfferings.ts
+++ b/src/apis/courseOfferings.ts
@@ -41,6 +41,21 @@ export function matchesCourseOfferingFilters(
     return false;
   }
   if (
+    filters?.ssupTypeNames?.length &&
+    !filters.ssupTypeNames.some((st) => {
+      const code = offering.ssupTypeCode;
+      const name = offering.ssupTypeName;
+      return (
+        code === st ||
+        name === st ||
+        (code && code.toLowerCase() === st.toLowerCase()) ||
+        (name && name.toLowerCase() === st.toLowerCase())
+      );
+    })
+  ) {
+    return false;
+  }
+  if (
     filters?.credits?.length &&
     !filters.credits.includes(offering.credit ?? Number(course?.credit))
   ) {

--- a/src/components/mobile/timetable/ClassDetailBottomSheet.tsx
+++ b/src/components/mobile/timetable/ClassDetailBottomSheet.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect, useRef, useMemo } from "react";
 import { useTimetableStore } from "@/stores/useTimetableStore";
 import { useCourses } from "@/hooks/useCourses";
 import { useCourseOfferings } from "@/hooks/useCourseOfferings";
+import { getOnlineTypeLabel } from "@/components/mobile/timetable/filter/courseFilterModel";
 
 const SYLLABUS_UNAVAILABLE_MESSAGE =
   "현 시점에는 제공되지 않아요. 원동력을 위해 학우 여러분의 많은 관심과 성원을 부탁드립니다!";
@@ -172,7 +173,12 @@ export default function ClassDetailBottomSheet({
 
   const courseIdStr = offering?.subjectNumber || liveClass.courseId || "";
 
-  const detailsList = [gradeStr, courseTypeStr, courseIdStr].filter(Boolean);
+  const onlineTypeStr = getOnlineTypeLabel(
+    offering?.ssupTypeName || liveClass.ssupTypeName,
+    offering?.ssupTypeCode || liveClass.ssupTypeCode,
+  );
+
+  const detailsList = [gradeStr, courseTypeStr, onlineTypeStr, courseIdStr].filter(Boolean);
   const detailsText = detailsList.join("  ");
 
   const scheduleText = matchingClasses

--- a/src/components/mobile/timetable/MobileCourseSearchSheet.tsx
+++ b/src/components/mobile/timetable/MobileCourseSearchSheet.tsx
@@ -20,7 +20,10 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { ROUTES } from "@/constants/routes";
 import { mixpanelTrack } from "@/utils/mixpanel";
 import { useEffectiveCourseFilters } from "@/stores/useCourseFilterStore";
-import { countActiveFilters } from "@/components/mobile/timetable/filter/courseFilterModel";
+import {
+  countActiveFilters,
+  getOnlineTypeLabel,
+} from "@/components/mobile/timetable/filter/courseFilterModel";
 import { mapFilterToOfferingFilters } from "@/utils/courseSearchResult";
 import Skeleton from "@/components/common/Skeleton";
 
@@ -385,6 +388,10 @@ const MobileCourseSearchSheet = ({
                     (addedCourseOfferingIds && addedCourseOfferingIds.has(course.id)) ||
                     (course.courseId && addedCourseIds && addedCourseIds.has(course.courseId)),
                   );
+                  const onlineTypeLabel = getOnlineTypeLabel(
+                    course.ssupTypeName,
+                    course.ssupTypeCode,
+                  );
 
                   return (
                     <CourseItem
@@ -424,6 +431,7 @@ const MobileCourseSearchSheet = ({
                               두 갈래로 뭉개면 전공핵심·전공기초가 "전공심화"로, 교직·
                               일반선택이 "교양"으로 잘못 표시된다. */}
                           <span>{course.isuName || "-"}</span>
+                          {onlineTypeLabel && <span>{onlineTypeLabel}</span>}
                           <span>{course.courseId}</span>
                         </InfoLine>
                         <div>{course.timeStr}</div>

--- a/src/components/mobile/timetable/MobileCourseSearchSheet.tsx
+++ b/src/components/mobile/timetable/MobileCourseSearchSheet.tsx
@@ -20,6 +20,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { ROUTES } from "@/constants/routes";
 import { mixpanelTrack } from "@/utils/mixpanel";
 import { useEffectiveCourseFilters } from "@/stores/useCourseFilterStore";
+import { countActiveFilters } from "@/components/mobile/timetable/filter/courseFilterModel";
 import { mapFilterToOfferingFilters } from "@/utils/courseSearchResult";
 import Skeleton from "@/components/common/Skeleton";
 
@@ -42,6 +43,8 @@ export interface CourseResult {
   collegeName?: string;
   isuName?: string;
   hyName?: string;
+  ssupTypeName?: string;
+  ssupTypeCode?: string;
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -159,16 +162,10 @@ const MobileCourseSearchSheet = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeFilters]);
 
-  const activeFilterCount = useMemo(() => {
-    let count = 0;
-    if (activeFilters.major) count++;
-    if (activeFilters.sort !== "기본순") count++;
-    if (activeFilters.time !== "전체 시간") count++;
-    count += activeFilters.grades.length;
-    count += activeFilters.types.length;
-    count += activeFilters.credits.length;
-    return count;
-  }, [activeFilters]);
+  const activeFilterCount = useMemo(
+    () => countActiveFilters(activeFilters),
+    [activeFilters],
+  );
 
   const [searchParams] = useSearchParams();
   const keyword = searchParams.get("courseQuery");
@@ -187,7 +184,8 @@ const MobileCourseSearchSheet = ({
             !c.deptName ||
             c.deptName === targetDept ||
             c.deptName.includes(targetDept) ||
-            targetDept.includes(c.deptName),
+            targetDept.includes(c.deptName) ||
+            Boolean(offeringFilters.ssupTypeNames?.length),
         );
       }
 
@@ -198,7 +196,8 @@ const MobileCourseSearchSheet = ({
             !c.collegeName ||
             c.collegeName === targetCollege ||
             c.collegeName.includes(targetCollege) ||
-            targetCollege.includes(c.collegeName),
+            targetCollege.includes(c.collegeName) ||
+            Boolean(offeringFilters.ssupTypeNames?.length),
         );
       }
 
@@ -217,6 +216,21 @@ const MobileCourseSearchSheet = ({
             !c.isuName ||
             offeringFilters.isuNames?.some((isu) => c.isuName?.includes(isu)),
         );
+      }
+      if (offeringFilters.ssupTypeNames?.length) {
+        list = list.filter((c) => {
+          if (!c.ssupTypeName && !c.ssupTypeCode) return true;
+          return offeringFilters.ssupTypeNames?.some((st) => {
+            const code = c.ssupTypeCode;
+            const name = c.ssupTypeName;
+            return (
+              code === st ||
+              name === st ||
+              (code && code.toLowerCase() === st.toLowerCase()) ||
+              (name && name.toLowerCase() === st.toLowerCase())
+            );
+          });
+        });
       }
       if (offeringFilters.credits?.length) {
         list = list.filter((c) => offeringFilters.credits?.includes(c.credits));

--- a/src/components/mobile/timetable/TimetableGrid.tsx
+++ b/src/components/mobile/timetable/TimetableGrid.tsx
@@ -30,6 +30,8 @@ export interface ClassItem {
   evaluation?: string;
   courseId?: string;
   numericCourseId?: number;
+  ssupTypeName?: string;
+  ssupTypeCode?: string;
   isCustom?: boolean;
   isUntimed?: boolean;
 }

--- a/src/components/mobile/timetable/filter/CourseFilterPanel.tsx
+++ b/src/components/mobile/timetable/filter/CourseFilterPanel.tsx
@@ -13,6 +13,7 @@ import {
   DEFAULT_FILTERS,
   GRADE_OPTIONS,
   MAJOR_CATEGORIES,
+  ONLINE_TYPE_OPTIONS,
   PINNED_MAJORS_STORAGE_KEY,
   SORT_OPTIONS,
   SUB_MAJORS,
@@ -422,6 +423,37 @@ const CourseFilterPanel = ({
               <CheckboxWrapper>
                 <CheckboxInput type="checkbox" checked={filters.types.includes(t)} readOnly />
                 <OptionLabel>{t}</OptionLabel>
+              </CheckboxWrapper>
+              <Ripple />
+            </OptionItemRow>
+          ))}
+        </OptionsCard>
+        <PanelBottomSpacer />
+      </PanelScroll>
+    );
+  }
+
+  if (view === "online") {
+    return (
+      <PanelScroll>
+        <OptionsCard>
+          {ONLINE_TYPE_OPTIONS.map((ot) => (
+            <OptionItemRow
+              key={ot}
+              onClick={() =>
+                onFiltersChange({
+                  ...filters,
+                  onlineTypes: toggleInList(filters.onlineTypes ?? [], ot),
+                })
+              }
+            >
+              <CheckboxWrapper>
+                <CheckboxInput
+                  type="checkbox"
+                  checked={(filters.onlineTypes ?? []).includes(ot)}
+                  readOnly
+                />
+                <OptionLabel>{ot}</OptionLabel>
               </CheckboxWrapper>
               <Ripple />
             </OptionItemRow>

--- a/src/components/mobile/timetable/filter/__tests__/courseFilterModel.test.ts
+++ b/src/components/mobile/timetable/filter/__tests__/courseFilterModel.test.ts
@@ -22,6 +22,7 @@ let DEFAULT_FILTERS: typeof import("../courseFilterModel").DEFAULT_FILTERS;
 let ONLINE_TYPE_OPTIONS: typeof import("../courseFilterModel").ONLINE_TYPE_OPTIONS;
 let ONLINE_TYPE_TO_SSUP_NAMES: typeof import("../courseFilterModel").ONLINE_TYPE_TO_SSUP_NAMES;
 let expandOnlineTypeLabel: typeof import("../courseFilterModel").expandOnlineTypeLabel;
+let getOnlineTypeLabel: typeof import("../courseFilterModel").getOnlineTypeLabel;
 let countActiveFilters: typeof import("../courseFilterModel").countActiveFilters;
 let buildCategoryChips: typeof import("../courseFilterModel").buildCategoryChips;
 let removeChipFromFilters: typeof import("../courseFilterModel").removeChipFromFilters;
@@ -34,6 +35,7 @@ beforeAll(async () => {
   ONLINE_TYPE_OPTIONS = model.ONLINE_TYPE_OPTIONS;
   ONLINE_TYPE_TO_SSUP_NAMES = model.ONLINE_TYPE_TO_SSUP_NAMES;
   expandOnlineTypeLabel = model.expandOnlineTypeLabel;
+  getOnlineTypeLabel = model.getOnlineTypeLabel;
   countActiveFilters = model.countActiveFilters;
   buildCategoryChips = model.buildCategoryChips;
   removeChipFromFilters = model.removeChipFromFilters;
@@ -56,10 +58,20 @@ describe("courseFilterModel & online filter tests", () => {
     expect(expandOnlineTypeLabel("이러닝")).toEqual(["e-Learning", "E_LEARNING"]);
     expect(expandOnlineTypeLabel("이러닝(HUSS)")).toEqual(["e-Learning(HUSS)", "E_LEARNING_HUSS"]);
     expect(expandOnlineTypeLabel("OCU")).toEqual(["열린사이버대학(OCU)", "OCU"]);
-    expect(expandOnlineTypeLabel("블렌디드 온라인")).toEqual(["온라인혼합형강좌", "BLENDED_ONLINE_COURSE"]);
-    expect(expandOnlineTypeLabel("블렌디드 온라인(HUSS)")).toEqual(["온라인혼합형강좌(HUSS)", "BLENDED_ONLINE_COURSE_HUSS"]);
+    expect(expandOnlineTypeLabel("온라인 혼합")).toEqual(["온라인혼합형강좌", "BLENDED_ONLINE_COURSE"]);
+    expect(expandOnlineTypeLabel("온라인 혼합(HUSS)")).toEqual(["온라인혼합형강좌(HUSS)", "BLENDED_ONLINE_COURSE_HUSS"]);
     expect(expandOnlineTypeLabel("K-MOOC")).toEqual(["K-MOOC", "K_MOOC"]);
     expect(expandOnlineTypeLabel("RISE(시간표 없음)")).toEqual(["RISE(시간표 없음)", "RISE_WITHOUT_TIMETABLE"]);
+  });
+
+  test("getOnlineTypeLabel correctly extracts UI display label for online course types", () => {
+    expect(getOnlineTypeLabel("e-Learning", "E_LEARNING")).toBe("이러닝");
+    expect(getOnlineTypeLabel(null, "E_LEARNING")).toBe("이러닝");
+    expect(getOnlineTypeLabel("열린사이버대학(OCU)", "OCU")).toBe("OCU");
+    expect(getOnlineTypeLabel("온라인혼합형강좌")).toBe("온라인 혼합");
+    expect(getOnlineTypeLabel("K-MOOC")).toBe("K-MOOC");
+    expect(getOnlineTypeLabel("강의(이론)", "OFFLINE")).toBe(null);
+    expect(getOnlineTypeLabel(null, null)).toBe(null);
   });
 
   test("countActiveFilters includes onlineTypes", () => {

--- a/src/components/mobile/timetable/filter/__tests__/courseFilterModel.test.ts
+++ b/src/components/mobile/timetable/filter/__tests__/courseFilterModel.test.ts
@@ -1,0 +1,142 @@
+if (typeof localStorage === "undefined") {
+  const store: Record<string, string> = {};
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      for (const k in store) delete store[k];
+    },
+    length: 0,
+    key: () => null,
+  };
+}
+
+import { describe, expect, test, beforeAll } from "vitest";
+
+let DEFAULT_FILTERS: typeof import("../courseFilterModel").DEFAULT_FILTERS;
+let ONLINE_TYPE_OPTIONS: typeof import("../courseFilterModel").ONLINE_TYPE_OPTIONS;
+let ONLINE_TYPE_TO_SSUP_NAME: typeof import("../courseFilterModel").ONLINE_TYPE_TO_SSUP_NAME;
+let expandOnlineTypeLabel: typeof import("../courseFilterModel").expandOnlineTypeLabel;
+let countActiveFilters: typeof import("../courseFilterModel").countActiveFilters;
+let buildCategoryChips: typeof import("../courseFilterModel").buildCategoryChips;
+let removeChipFromFilters: typeof import("../courseFilterModel").removeChipFromFilters;
+let mapFilterToOfferingFilters: typeof import("@/utils/courseSearchResult").mapFilterToOfferingFilters;
+let matchesCourseOfferingFilters: typeof import("@/apis/courseOfferings").matchesCourseOfferingFilters;
+
+beforeAll(async () => {
+  const model = await import("../courseFilterModel");
+  DEFAULT_FILTERS = model.DEFAULT_FILTERS;
+  ONLINE_TYPE_OPTIONS = model.ONLINE_TYPE_OPTIONS;
+  ONLINE_TYPE_TO_SSUP_NAME = model.ONLINE_TYPE_TO_SSUP_NAME;
+  expandOnlineTypeLabel = model.expandOnlineTypeLabel;
+  countActiveFilters = model.countActiveFilters;
+  buildCategoryChips = model.buildCategoryChips;
+  removeChipFromFilters = model.removeChipFromFilters;
+
+  const resultUtil = await import("@/utils/courseSearchResult");
+  mapFilterToOfferingFilters = resultUtil.mapFilterToOfferingFilters;
+
+  const api = await import("@/apis/courseOfferings");
+  matchesCourseOfferingFilters = api.matchesCourseOfferingFilters;
+});
+
+describe("courseFilterModel & online filter tests", () => {
+  test("DEFAULT_FILTERS initialized with empty onlineTypes", () => {
+    expect(DEFAULT_FILTERS.onlineTypes).toEqual([]);
+    expect(ONLINE_TYPE_OPTIONS.length).toBeGreaterThan(0);
+    expect(Object.keys(ONLINE_TYPE_TO_SSUP_NAME).length).toBeGreaterThan(0);
+  });
+
+  test("ONLINE_TYPE_TO_SSUP_NAME maps UI labels to backend SSUP_TYPE_NAME enums", () => {
+    expect(expandOnlineTypeLabel("이러닝")).toBe("E_LEARNING");
+    expect(expandOnlineTypeLabel("이러닝(HUSS)")).toBe("E_LEARNING_HUSS");
+    expect(expandOnlineTypeLabel("OCU")).toBe("OCU");
+    expect(expandOnlineTypeLabel("블렌디드 온라인")).toBe("BLENDED_ONLINE_COURSE");
+    expect(expandOnlineTypeLabel("블렌디드 온라인(HUSS)")).toBe("BLENDED_ONLINE_COURSE_HUSS");
+    expect(expandOnlineTypeLabel("K-MOOC")).toBe("K_MOOC");
+    expect(expandOnlineTypeLabel("RISE(시간표 없음)")).toBe("RISE_WITHOUT_TIMETABLE");
+  });
+
+  test("countActiveFilters includes onlineTypes", () => {
+    const filters = {
+      ...DEFAULT_FILTERS,
+      onlineTypes: ["이러닝", "OCU"],
+    };
+    expect(countActiveFilters(filters)).toBe(2);
+  });
+
+  test("buildCategoryChips creates chips for online category", () => {
+    const filters = {
+      ...DEFAULT_FILTERS,
+      onlineTypes: ["이러닝", "K-MOOC"],
+    };
+    const chips = buildCategoryChips(filters);
+    expect(chips.online).toEqual(["이러닝", "K-MOOC"]);
+  });
+
+  test("removeChipFromFilters removes specified chip from onlineTypes", () => {
+    const filters = {
+      ...DEFAULT_FILTERS,
+      onlineTypes: ["이러닝", "OCU"],
+    };
+    const updated = removeChipFromFilters(filters, "online", "이러닝");
+    expect(updated.onlineTypes).toEqual(["OCU"]);
+  });
+
+  test("mapFilterToOfferingFilters maps onlineTypes to ssupTypeNames", () => {
+    const filters = {
+      ...DEFAULT_FILTERS,
+      onlineTypes: ["이러닝", "OCU"],
+    };
+    const mapped = mapFilterToOfferingFilters(filters);
+    expect(mapped.ssupTypeNames).toEqual(["E_LEARNING", "OCU"]);
+  });
+
+  test("matchesCourseOfferingFilters correctly filters offerings by ssupTypeNames", () => {
+    const offering1: import("@/types/courseOfferings").CourseOffering = {
+      id: 1,
+      syllabus: null,
+      subjectNumber: "10001001",
+      professor: null,
+      courseId: 100,
+      courseTitle: "이러닝 과목",
+      semesterId: 1,
+      year: 2026,
+      term: "FIRST",
+      capacity: 50,
+      enrolledCount: 30,
+      note: null,
+      meetings: [],
+      ssupTypeCode: "E_LEARNING",
+      ssupTypeName: "E_LEARNING",
+    };
+
+    const offering2: import("@/types/courseOfferings").CourseOffering = {
+      id: 2,
+      syllabus: null,
+      subjectNumber: "10002001",
+      professor: null,
+      courseId: 101,
+      courseTitle: "일반 오프라인 과목",
+      semesterId: 1,
+      year: 2026,
+      term: "FIRST",
+      capacity: 50,
+      enrolledCount: 30,
+      note: null,
+      meetings: [],
+      ssupTypeCode: "OFFLINE",
+      ssupTypeName: "OFFLINE",
+    };
+
+    const filters = { ssupTypeNames: ["E_LEARNING", "OCU"] };
+
+    expect(matchesCourseOfferingFilters(offering1, undefined, filters)).toBe(true);
+    expect(matchesCourseOfferingFilters(offering2, undefined, filters)).toBe(false);
+  });
+});

--- a/src/components/mobile/timetable/filter/__tests__/courseFilterModel.test.ts
+++ b/src/components/mobile/timetable/filter/__tests__/courseFilterModel.test.ts
@@ -20,28 +20,28 @@ import { describe, expect, test, beforeAll } from "vitest";
 
 let DEFAULT_FILTERS: typeof import("../courseFilterModel").DEFAULT_FILTERS;
 let ONLINE_TYPE_OPTIONS: typeof import("../courseFilterModel").ONLINE_TYPE_OPTIONS;
-let ONLINE_TYPE_TO_SSUP_NAME: typeof import("../courseFilterModel").ONLINE_TYPE_TO_SSUP_NAME;
+let ONLINE_TYPE_TO_SSUP_NAMES: typeof import("../courseFilterModel").ONLINE_TYPE_TO_SSUP_NAMES;
 let expandOnlineTypeLabel: typeof import("../courseFilterModel").expandOnlineTypeLabel;
 let countActiveFilters: typeof import("../courseFilterModel").countActiveFilters;
 let buildCategoryChips: typeof import("../courseFilterModel").buildCategoryChips;
 let removeChipFromFilters: typeof import("../courseFilterModel").removeChipFromFilters;
-let mapFilterToOfferingFilters: typeof import("@/utils/courseSearchResult").mapFilterToOfferingFilters;
-let matchesCourseOfferingFilters: typeof import("@/apis/courseOfferings").matchesCourseOfferingFilters;
+let mapFilterToOfferingFilters: typeof import("../../../../../utils/courseSearchResult").mapFilterToOfferingFilters;
+let matchesCourseOfferingFilters: typeof import("../../../../../apis/courseOfferings").matchesCourseOfferingFilters;
 
 beforeAll(async () => {
   const model = await import("../courseFilterModel");
   DEFAULT_FILTERS = model.DEFAULT_FILTERS;
   ONLINE_TYPE_OPTIONS = model.ONLINE_TYPE_OPTIONS;
-  ONLINE_TYPE_TO_SSUP_NAME = model.ONLINE_TYPE_TO_SSUP_NAME;
+  ONLINE_TYPE_TO_SSUP_NAMES = model.ONLINE_TYPE_TO_SSUP_NAMES;
   expandOnlineTypeLabel = model.expandOnlineTypeLabel;
   countActiveFilters = model.countActiveFilters;
   buildCategoryChips = model.buildCategoryChips;
   removeChipFromFilters = model.removeChipFromFilters;
 
-  const resultUtil = await import("@/utils/courseSearchResult");
+  const resultUtil = await import("../../../../../utils/courseSearchResult");
   mapFilterToOfferingFilters = resultUtil.mapFilterToOfferingFilters;
 
-  const api = await import("@/apis/courseOfferings");
+  const api = await import("../../../../../apis/courseOfferings");
   matchesCourseOfferingFilters = api.matchesCourseOfferingFilters;
 });
 
@@ -49,17 +49,17 @@ describe("courseFilterModel & online filter tests", () => {
   test("DEFAULT_FILTERS initialized with empty onlineTypes", () => {
     expect(DEFAULT_FILTERS.onlineTypes).toEqual([]);
     expect(ONLINE_TYPE_OPTIONS.length).toBeGreaterThan(0);
-    expect(Object.keys(ONLINE_TYPE_TO_SSUP_NAME).length).toBeGreaterThan(0);
+    expect(Object.keys(ONLINE_TYPE_TO_SSUP_NAMES).length).toBeGreaterThan(0);
   });
 
-  test("ONLINE_TYPE_TO_SSUP_NAME maps UI labels to backend SSUP_TYPE_NAME enums", () => {
-    expect(expandOnlineTypeLabel("이러닝")).toBe("E_LEARNING");
-    expect(expandOnlineTypeLabel("이러닝(HUSS)")).toBe("E_LEARNING_HUSS");
-    expect(expandOnlineTypeLabel("OCU")).toBe("OCU");
-    expect(expandOnlineTypeLabel("블렌디드 온라인")).toBe("BLENDED_ONLINE_COURSE");
-    expect(expandOnlineTypeLabel("블렌디드 온라인(HUSS)")).toBe("BLENDED_ONLINE_COURSE_HUSS");
-    expect(expandOnlineTypeLabel("K-MOOC")).toBe("K_MOOC");
-    expect(expandOnlineTypeLabel("RISE(시간표 없음)")).toBe("RISE_WITHOUT_TIMETABLE");
+  test("ONLINE_TYPE_TO_SSUP_NAMES maps UI labels to backend ssupTypeName strings and enums", () => {
+    expect(expandOnlineTypeLabel("이러닝")).toEqual(["e-Learning", "E_LEARNING"]);
+    expect(expandOnlineTypeLabel("이러닝(HUSS)")).toEqual(["e-Learning(HUSS)", "E_LEARNING_HUSS"]);
+    expect(expandOnlineTypeLabel("OCU")).toEqual(["열린사이버대학(OCU)", "OCU"]);
+    expect(expandOnlineTypeLabel("블렌디드 온라인")).toEqual(["온라인혼합형강좌", "BLENDED_ONLINE_COURSE"]);
+    expect(expandOnlineTypeLabel("블렌디드 온라인(HUSS)")).toEqual(["온라인혼합형강좌(HUSS)", "BLENDED_ONLINE_COURSE_HUSS"]);
+    expect(expandOnlineTypeLabel("K-MOOC")).toEqual(["K-MOOC", "K_MOOC"]);
+    expect(expandOnlineTypeLabel("RISE(시간표 없음)")).toEqual(["RISE(시간표 없음)", "RISE_WITHOUT_TIMETABLE"]);
   });
 
   test("countActiveFilters includes onlineTypes", () => {
@@ -88,17 +88,22 @@ describe("courseFilterModel & online filter tests", () => {
     expect(updated.onlineTypes).toEqual(["OCU"]);
   });
 
-  test("mapFilterToOfferingFilters maps onlineTypes to ssupTypeNames", () => {
+  test("mapFilterToOfferingFilters maps onlineTypes to ssupTypeNames array", () => {
     const filters = {
       ...DEFAULT_FILTERS,
       onlineTypes: ["이러닝", "OCU"],
     };
     const mapped = mapFilterToOfferingFilters(filters);
-    expect(mapped.ssupTypeNames).toEqual(["E_LEARNING", "OCU"]);
+    expect(mapped.ssupTypeNames).toEqual([
+      "e-Learning",
+      "E_LEARNING",
+      "열린사이버대학(OCU)",
+      "OCU",
+    ]);
   });
 
   test("matchesCourseOfferingFilters correctly filters offerings by ssupTypeNames", () => {
-    const offering1: import("@/types/courseOfferings").CourseOffering = {
+    const offering1: import("../../../../../types/courseOfferings").CourseOffering = {
       id: 1,
       syllabus: null,
       subjectNumber: "10001001",
@@ -113,10 +118,10 @@ describe("courseFilterModel & online filter tests", () => {
       note: null,
       meetings: [],
       ssupTypeCode: "E_LEARNING",
-      ssupTypeName: "E_LEARNING",
+      ssupTypeName: "e-Learning",
     };
 
-    const offering2: import("@/types/courseOfferings").CourseOffering = {
+    const offering2: import("../../../../../types/courseOfferings").CourseOffering = {
       id: 2,
       syllabus: null,
       subjectNumber: "10002001",
@@ -131,10 +136,10 @@ describe("courseFilterModel & online filter tests", () => {
       note: null,
       meetings: [],
       ssupTypeCode: "OFFLINE",
-      ssupTypeName: "OFFLINE",
+      ssupTypeName: "강의(이론)",
     };
 
-    const filters = { ssupTypeNames: ["E_LEARNING", "OCU"] };
+    const filters = { ssupTypeNames: ["e-Learning", "E_LEARNING", "열린사이버대학(OCU)", "OCU"] };
 
     expect(matchesCourseOfferingFilters(offering1, undefined, filters)).toBe(true);
     expect(matchesCourseOfferingFilters(offering2, undefined, filters)).toBe(false);

--- a/src/components/mobile/timetable/filter/courseFilterModel.ts
+++ b/src/components/mobile/timetable/filter/courseFilterModel.ts
@@ -67,18 +67,18 @@ export const ONLINE_TYPE_OPTIONS = [
   "RISE(시간표 없음)",
 ] as const;
 
-export const ONLINE_TYPE_TO_SSUP_NAME: Record<string, string> = {
-  이러닝: "E_LEARNING",
-  "이러닝(HUSS)": "E_LEARNING_HUSS",
-  OCU: "OCU",
-  "블렌디드 온라인": "BLENDED_ONLINE_COURSE",
-  "블렌디드 온라인(HUSS)": "BLENDED_ONLINE_COURSE_HUSS",
-  "K-MOOC": "K_MOOC",
-  "RISE(시간표 없음)": "RISE_WITHOUT_TIMETABLE",
+export const ONLINE_TYPE_TO_SSUP_NAMES: Record<string, readonly string[]> = {
+  이러닝: ["e-Learning", "E_LEARNING"],
+  "이러닝(HUSS)": ["e-Learning(HUSS)", "E_LEARNING_HUSS"],
+  OCU: ["열린사이버대학(OCU)", "OCU"],
+  "블렌디드 온라인": ["온라인혼합형강좌", "BLENDED_ONLINE_COURSE"],
+  "블렌디드 온라인(HUSS)": ["온라인혼합형강좌(HUSS)", "BLENDED_ONLINE_COURSE_HUSS"],
+  "K-MOOC": ["K-MOOC", "K_MOOC"],
+  "RISE(시간표 없음)": ["RISE(시간표 없음)", "RISE_WITHOUT_TIMETABLE"],
 };
 
-export const expandOnlineTypeLabel = (label: string): string =>
-  ONLINE_TYPE_TO_SSUP_NAME[label] ?? label;
+export const expandOnlineTypeLabel = (label: string): readonly string[] =>
+  ONLINE_TYPE_TO_SSUP_NAMES[label] ?? [label];
 
 export const SORT_OPTIONS = ["기본순", "별점높은순", "담은인원많은순"] as const;
 export const TYPE_OPTIONS = ["전공", "교양", "교직", "일반선택", "군사학"] as const;

--- a/src/components/mobile/timetable/filter/courseFilterModel.ts
+++ b/src/components/mobile/timetable/filter/courseFilterModel.ts
@@ -9,6 +9,7 @@ export interface FilterState {
   grades: number[];
   types: string[];
   credits: number[];
+  onlineTypes: string[];
   selectedSlots?: string[];
 }
 
@@ -19,6 +20,7 @@ export const DEFAULT_FILTERS: FilterState = {
   grades: [],
   types: [],
   credits: [],
+  onlineTypes: [],
   selectedSlots: [],
 };
 
@@ -29,7 +31,8 @@ export type FilterSubView =
   | "time"
   | "grade"
   | "type"
-  | "credit";
+  | "credit"
+  | "online";
 
 export const CATEGORIES = [
   { id: "major", label: "전공/영역" },
@@ -37,6 +40,7 @@ export const CATEGORIES = [
   { id: "time", label: "시간" },
   { id: "grade", label: "학년" },
   { id: "type", label: "이수구분" },
+  { id: "online", label: "이러닝/온라인" },
   { id: "credit", label: "학점" },
 ] as const;
 
@@ -49,8 +53,32 @@ export const FILTER_SUB_VIEW_TITLES: Record<FilterSubView, string> = {
   time: "시간",
   grade: "학년",
   type: "이수구분",
+  online: "이러닝/온라인",
   credit: "학점",
 };
+
+export const ONLINE_TYPE_OPTIONS = [
+  "이러닝",
+  "이러닝(HUSS)",
+  "OCU",
+  "블렌디드 온라인",
+  "블렌디드 온라인(HUSS)",
+  "K-MOOC",
+  "RISE(시간표 없음)",
+] as const;
+
+export const ONLINE_TYPE_TO_SSUP_NAME: Record<string, string> = {
+  이러닝: "E_LEARNING",
+  "이러닝(HUSS)": "E_LEARNING_HUSS",
+  OCU: "OCU",
+  "블렌디드 온라인": "BLENDED_ONLINE_COURSE",
+  "블렌디드 온라인(HUSS)": "BLENDED_ONLINE_COURSE_HUSS",
+  "K-MOOC": "K_MOOC",
+  "RISE(시간표 없음)": "RISE_WITHOUT_TIMETABLE",
+};
+
+export const expandOnlineTypeLabel = (label: string): string =>
+  ONLINE_TYPE_TO_SSUP_NAME[label] ?? label;
 
 export const SORT_OPTIONS = ["기본순", "별점높은순", "담은인원많은순"] as const;
 export const TYPE_OPTIONS = ["전공", "교양", "교직", "일반선택", "군사학"] as const;
@@ -292,6 +320,7 @@ export function countActiveFilters(filters: FilterState): number {
   if (filters.time !== DEFAULT_FILTERS.time) count += 1;
   count += filters.grades.length;
   count += filters.types.length;
+  count += filters.onlineTypes?.length ?? 0;
   count += filters.credits.length;
   return count;
 }
@@ -311,6 +340,7 @@ export function buildCategoryChips(
         : filters.time.split(" "),
     grade: filters.grades.map((g) => `${g}학년`),
     type: [...filters.types],
+    online: [...(filters.onlineTypes ?? [])],
     credit: filters.credits.map((c) => (c === 4 ? "4학점 이상" : `${c}학점`)),
   };
 }
@@ -346,6 +376,11 @@ export function removeChipFromFilters(
     }
     case "type":
       return { ...filters, types: filters.types.filter((t) => t !== chip) };
+    case "online":
+      return {
+        ...filters,
+        onlineTypes: (filters.onlineTypes ?? []).filter((t) => t !== chip),
+      };
     case "credit": {
       const val = chip === "4학점 이상" ? 4 : parseInt(chip.replace("학점", ""), 10);
       return { ...filters, credits: filters.credits.filter((c) => c !== val) };

--- a/src/components/mobile/timetable/filter/courseFilterModel.ts
+++ b/src/components/mobile/timetable/filter/courseFilterModel.ts
@@ -61,8 +61,8 @@ export const ONLINE_TYPE_OPTIONS = [
   "이러닝",
   "이러닝(HUSS)",
   "OCU",
-  "블렌디드 온라인",
-  "블렌디드 온라인(HUSS)",
+  "온라인 혼합",
+  "온라인 혼합(HUSS)",
   "K-MOOC",
   "RISE(시간표 없음)",
 ] as const;
@@ -71,14 +71,34 @@ export const ONLINE_TYPE_TO_SSUP_NAMES: Record<string, readonly string[]> = {
   이러닝: ["e-Learning", "E_LEARNING"],
   "이러닝(HUSS)": ["e-Learning(HUSS)", "E_LEARNING_HUSS"],
   OCU: ["열린사이버대학(OCU)", "OCU"],
-  "블렌디드 온라인": ["온라인혼합형강좌", "BLENDED_ONLINE_COURSE"],
-  "블렌디드 온라인(HUSS)": ["온라인혼합형강좌(HUSS)", "BLENDED_ONLINE_COURSE_HUSS"],
+  "온라인 혼합": ["온라인혼합형강좌", "BLENDED_ONLINE_COURSE"],
+  "온라인 혼합(HUSS)": ["온라인혼합형강좌(HUSS)", "BLENDED_ONLINE_COURSE_HUSS"],
   "K-MOOC": ["K-MOOC", "K_MOOC"],
   "RISE(시간표 없음)": ["RISE(시간표 없음)", "RISE_WITHOUT_TIMETABLE"],
 };
 
 export const expandOnlineTypeLabel = (label: string): readonly string[] =>
   ONLINE_TYPE_TO_SSUP_NAMES[label] ?? [label];
+
+export function getOnlineTypeLabel(
+  ssupTypeName?: string | null,
+  ssupTypeCode?: string | null,
+): string | null {
+  const val = ssupTypeName || ssupTypeCode;
+  if (!val) return null;
+
+  const upper = val.toUpperCase();
+  if (upper === "OFFLINE" || val === "강의(이론)") return null;
+
+  for (const [label, names] of Object.entries(ONLINE_TYPE_TO_SSUP_NAMES)) {
+    if (names.some((n) => n.toLowerCase() === val.toLowerCase())) {
+      return label;
+    }
+  }
+
+  return ssupTypeName || ssupTypeCode || null;
+}
+
 
 export const SORT_OPTIONS = ["기본순", "별점높은순", "담은인원많은순"] as const;
 export const TYPE_OPTIONS = ["전공", "교양", "교직", "일반선택", "군사학"] as const;

--- a/src/components/mobile/timetable/wizard/WizardCourseSearchSheet.tsx
+++ b/src/components/mobile/timetable/wizard/WizardCourseSearchSheet.tsx
@@ -26,6 +26,7 @@ import CourseFilterPanel, {
 import {
   FILTER_SUB_VIEW_TITLES,
   countActiveFilters,
+  getOnlineTypeLabel,
 } from "@/components/mobile/timetable/filter/courseFilterModel";
 import { mapFilterToOfferingFilters } from "@/utils/courseSearchResult";
 import { toWizardCourseOption } from "@/utils/timetableWizardPool";
@@ -101,6 +102,7 @@ interface CourseRow {
   gradeLabel: string;
   isMajor: boolean;
   isuLabel: string;
+  onlineTypeLabel: string | null;
   timeStr: string;
   room: string;
   enrolledCount: number | null;
@@ -119,6 +121,10 @@ const buildCourseRow = (
   const gradeName = offering.hyName ?? course?.targetGradeName ?? "";
   const grade = parseInt(gradeName, 10);
   const isuName = offering.isuName ?? course?.completionDivisionName ?? "";
+  const onlineTypeLabel = getOnlineTypeLabel(
+    offering.ssupTypeName,
+    offering.ssupTypeCode,
+  );
 
   return {
     offeringId: offering.id,
@@ -131,6 +137,7 @@ const buildCourseRow = (
     // 서버 이수구분을 그대로 노출한다(전공기초/전공핵심/전공심화/기초교양/핵심교양/
     // 심화교양/교직/일반선택/군사학). 전공·교양 두 갈래로 뭉개면 실제와 어긋난다.
     isuLabel: isuName || "-",
+    onlineTypeLabel,
     timeStr: offering.meetings
       .map((m) => `${DAY_LABELS[DAY_INDEX[m.day]]} ${m.startTime}~${m.endTime}`)
       .join(", "),
@@ -414,6 +421,7 @@ const WizardCourseSearchSheet = () => {
                           <InfoLine>
                             <span>{row.gradeLabel}</span>
                             <span>{row.isuLabel}</span>
+                            {row.onlineTypeLabel && <span>{row.onlineTypeLabel}</span>}
                             <span>{row.subjectNumber}</span>
                           </InfoLine>
                           <div>{row.timeStr}</div>

--- a/src/components/mobile/timetable/wizard/WizardDetailScreen.tsx
+++ b/src/components/mobile/timetable/wizard/WizardDetailScreen.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { ChevronRight } from "lucide-react";
 import TimetableGrid from "@/components/mobile/timetable/TimetableGrid";
 import { formatCourseMeetings, mapWizardCoursesToClassItems } from "@/utils/timetableWizardFormat";
+import { getOnlineTypeLabel } from "@/components/mobile/timetable/filter/courseFilterModel";
 import type { WizardCandidate } from "@/types/timetableWizard";
 
 interface WizardDetailScreenProps {
@@ -39,18 +40,25 @@ const WizardDetailScreen = ({ candidate }: WizardDetailScreenProps) => {
       <Card>
         <CardTitle>강의 목록</CardTitle>
         <CourseList>
-          {candidate.courses.map((course, index) => (
-            <CourseRow key={course.subjectNumber}>
-              <AccentBar $colorIndex={index} />
-              <CourseTextWrap>
-                <CourseName>{course.title}</CourseName>
-                <CourseMeta>
-                  {formatCourseMeetings(course)} · {course.credit}학점
-                </CourseMeta>
-              </CourseTextWrap>
-              <ChevronRight size={18} color="#8a96a5" />
-            </CourseRow>
-          ))}
+          {candidate.courses.map((course, index) => {
+            const onlineTypeLabel = getOnlineTypeLabel(
+              course.ssupTypeName,
+              course.ssupTypeCode,
+            );
+            return (
+              <CourseRow key={course.subjectNumber}>
+                <AccentBar $colorIndex={index} />
+                <CourseTextWrap>
+                  <CourseName>{course.title}</CourseName>
+                  <CourseMeta>
+                    {formatCourseMeetings(course)} · {course.credit}학점
+                    {onlineTypeLabel ? ` · ${onlineTypeLabel}` : ""}
+                  </CourseMeta>
+                </CourseTextWrap>
+                <ChevronRight size={18} color="#8a96a5" />
+              </CourseRow>
+            );
+          })}
         </CourseList>
       </Card>
 

--- a/src/pages/mobile/timetable/MobileCourseFilterPage.tsx
+++ b/src/pages/mobile/timetable/MobileCourseFilterPage.tsx
@@ -243,6 +243,10 @@ export default function MobileCourseFilterPage() {
         title: FILTER_SUB_VIEW_TITLES.type,
         onBack: () => setView("main"),
       },
+      online: {
+        title: FILTER_SUB_VIEW_TITLES.online,
+        onBack: () => setView("main"),
+      },
       credit: {
         title: FILTER_SUB_VIEW_TITLES.credit,
         onBack: () => setView("main"),
@@ -301,6 +305,7 @@ export default function MobileCourseFilterPage() {
         filters.time !== "전체 시간" || Boolean(filters.selectedSlots?.length),
       grade_count: filters.grades.length,
       type_count: filters.types.length,
+      online_type_count: filters.onlineTypes?.length ?? 0,
       credit_count: filters.credits.length,
       sort: filters.sort,
     });
@@ -363,7 +368,7 @@ export default function MobileCourseFilterPage() {
               초기화
             </ResetBottomButton>
           )}
-          {(view === "grade" || view === "type" || view === "credit") && (
+          {(view === "grade" || view === "type" || view === "credit" || view === "online") && (
             <BottomActionButton
               variant="primary"
               onClick={() => setView("main")}

--- a/src/types/timetableWizard.ts
+++ b/src/types/timetableWizard.ts
@@ -19,6 +19,8 @@ export interface WizardCourseOption {
   credit: number;
   department: string | null;
   meetings: WizardCourseMeeting[];
+  ssupTypeName?: string | null;
+  ssupTypeCode?: string | null;
 }
 
 // "듣고 싶은 강의" 목록의 항목 하나.

--- a/src/utils/courseSearchResult.ts
+++ b/src/utils/courseSearchResult.ts
@@ -63,6 +63,7 @@ export const mapCourseOfferingToCourseResult = (
 import type { FilterState } from "@/components/mobile/timetable/filter/courseFilterModel";
 import {
   expandIsuNameLabel,
+  expandOnlineTypeLabel,
   isIsuNameLabel,
 } from "@/components/mobile/timetable/filter/courseFilterModel";
 import type { CourseOfferingFilters } from "@/types/courseOfferings";
@@ -162,12 +163,14 @@ export function mapFilterToOfferingFilters(filters: FilterState): CourseOffering
   }
 
   const meetings = filters.selectedSlots ? formatSlotsToMeetings(filters.selectedSlots) : [];
+  const ssupTypeNames = (filters.onlineTypes ?? []).map(expandOnlineTypeLabel);
 
   return {
     collegeName,
     deptName,
     hyNames: filters.grades.length > 0 ? filters.grades.map(String) : undefined,
     isuNames: isuNameSet.size > 0 ? [...isuNameSet] : undefined,
+    ssupTypeNames: ssupTypeNames.length > 0 ? ssupTypeNames : undefined,
     credits: filters.credits.length > 0 ? filters.credits : undefined,
     meetingFilterMode: meetings.length > 0 ? "HAS_CLASS" : undefined,
     meetings: meetings.length > 0 ? meetings : undefined,

--- a/src/utils/courseSearchResult.ts
+++ b/src/utils/courseSearchResult.ts
@@ -57,6 +57,8 @@ export const mapCourseOfferingToCourseResult = (
     collegeName: offering.collegeName ?? course?.collegeName,
     isuName: offering.isuName ?? course?.completionDivisionName,
     hyName: offering.hyName ?? course?.targetGradeName,
+    ssupTypeName: offering.ssupTypeName ?? undefined,
+    ssupTypeCode: offering.ssupTypeCode ?? undefined,
   };
 };
 

--- a/src/utils/courseSearchResult.ts
+++ b/src/utils/courseSearchResult.ts
@@ -163,7 +163,7 @@ export function mapFilterToOfferingFilters(filters: FilterState): CourseOffering
   }
 
   const meetings = filters.selectedSlots ? formatSlotsToMeetings(filters.selectedSlots) : [];
-  const ssupTypeNames = (filters.onlineTypes ?? []).map(expandOnlineTypeLabel);
+  const ssupTypeNames = (filters.onlineTypes ?? []).flatMap(expandOnlineTypeLabel);
 
   return {
     collegeName,

--- a/src/utils/timetableWizardFormat.ts
+++ b/src/utils/timetableWizardFormat.ts
@@ -26,5 +26,7 @@ export const mapWizardCoursesToClassItems = (
       endTime: meeting.endTime,
       credits: meetingIndex === 0 ? course.credit : 0,
       professor: course.professor ?? undefined,
+      ssupTypeName: course.ssupTypeName ?? undefined,
+      ssupTypeCode: course.ssupTypeCode ?? undefined,
     })),
   );

--- a/src/utils/timetableWizardPool.ts
+++ b/src/utils/timetableWizardPool.ts
@@ -17,7 +17,6 @@ export const toWizardCourseOption = (
   offering: CourseOffering,
   course: Course | undefined,
 ): WizardCourseOption | null => {
-  if (offering.meetings.length === 0) return null;
 
   const meetings: WizardCourseMeeting[] = offering.meetings.map((meeting) => ({
     day: DAY_INDEX[meeting.day],

--- a/src/utils/timetableWizardPool.ts
+++ b/src/utils/timetableWizardPool.ts
@@ -38,5 +38,7 @@ export const toWizardCourseOption = (
     credit: Number.isFinite(parsedCredit) ? parsedCredit : 0,
     department: offering.deptName ?? course?.departmentName ?? null,
     meetings,
+    ssupTypeName: offering.ssupTypeName ?? null,
+    ssupTypeCode: offering.ssupTypeCode ?? null,
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "types": ["node"]
   },
   "include": ["src", "src/types/turbo.d.ts"],
+  "exclude": ["node_modules", "src/**/__tests__"],
   "references": [
     {
       "path": "./tsconfig.node.json"


### PR DESCRIPTION
## 📌 개요
GitHub Issue #253 해결: 강의 검색 및 시간표 마법사 필터에 "이러닝·온라인" 필터 카테고리를 추가합니다.

## 📝 주요 변경 사항
- **courseFilterModel.ts**: `FilterState`에 `onlineTypes: string[]` 추가, `CATEGORIES` 및 `FILTER_SUB_VIEW_TITLES`에 "이러닝/온라인" 카테고리 추가, `countActiveFilters` / `buildCategoryChips` / `removeChipFromFilters` 반영
- **ONLINE_TYPE_TO_SSUP_NAME**: UI 선택 옵션(이러닝, OCU, K-MOOC, 블렌디드 등)을 서버 `SSUP_TYPE_NAME` enum 값으로 매핑 (`E_LEARNING`, `E_LEARNING_HUSS`, `OCU`, `BLENDED_ONLINE_COURSE`, `BLENDED_ONLINE_COURSE_HUSS`, `K_MOOC`, `RISE_WITHOUT_TIMETABLE`)
- **courseSearchResult.ts**: `mapFilterToOfferingFilters`에서 `filters.onlineTypes`를 `ssupTypeNames` 배열로 변환하여 API 쿼리로 전달
- **courseOfferings.ts**: `matchesCourseOfferingFilters`에 `ssupTypeNames` 검사 로직 추가 (목/로컬 필터링 용)
- **CourseFilterPanel.tsx & MobileCourseFilterPage.tsx**: 이러닝/온라인 선택 서브뷰 UI 및 칩/카운트 제거 연동
- **단위 테스트**: `courseFilterModel.test.ts` 작성 및 테스트 100% 통과 (18/18 passed)

Closes #253