### PR TITLE
fix: 시간표 마법사 저장 흐름 개선 (이름 입력 모달, 완료 후 선택 모달)

### DIFF
--- a/src/components/mobile/timetable/wizard/WizardSaveFlow.tsx
+++ b/src/components/mobile/timetable/wizard/WizardSaveFlow.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import BottomSheet from "@/components/common/BottomSheet";
 import Modal from "@/components/common/Modal";
 import CapsuleButton from "@/components/common/CapsuleButton";
+import InputField from "@/components/common/InputField";
 import {
   useCreateTimeTable,
   useCreateTimeTableCourseItem,
@@ -19,7 +20,10 @@ interface WizardSaveFlowProps {
   onOpenChange: (open: boolean) => void;
   candidate: WizardCandidate;
   semesterId: number | null;
-  onSaved: () => void;
+  /** 저장 완료 후 "더 많은 후보 생성"을 선택했을 때. 위시리스트 등 조건은 그대로 둔 채 재생성만 트리거한다. */
+  onGenerateMore: () => void;
+  /** 저장 완료 후 "시간표 보러 가기"를 선택했을 때. 저장된 시간표 id를 넘긴다. */
+  onViewTimetable: (timeTableId: number) => void;
 }
 
 type SaveMode = "new" | "overwrite";
@@ -29,12 +33,19 @@ const WizardSaveFlow = ({
   onOpenChange,
   candidate,
   semesterId,
-  onSaved,
+  onGenerateMore,
+  onViewTimetable,
 }: WizardSaveFlowProps) => {
   const [mode, setMode] = useState<SaveMode>("new");
   const [targetTimetableId, setTargetTimetableId] = useState<number | null>(null);
   const [isOverwriteConfirmOpen, setOverwriteConfirmOpen] = useState(false);
   const [isSaving, setSaving] = useState(false);
+  // 새 시간표 이름 입력 모달. "이미 있는 이름이면 저장 실패"를 저장 시도 후에야
+  // 알게 되는 게 아니라, 저장 전에 사용자가 직접 이름을 정하고 실패 시 즉시 고칠 수 있게 한다.
+  const [isNameModalOpen, setNameModalOpen] = useState(false);
+  const [nameDraft, setNameDraft] = useState("");
+  // 저장 완료 후 "더 많은 후보 생성 / 시간표 보러 가기"를 고르는 모달. 저장된 시간표 id를 들고 있는다.
+  const [savedTimetableId, setSavedTimetableId] = useState<number | null>(null);
 
   const { timeTables: semesterTimetables } = useSemesterTimeTables(
     semesterId ?? undefined,
@@ -58,22 +69,25 @@ const WizardSaveFlow = ({
     }
   };
 
-  const handleSaveAsNew = async () => {
-    if (!semesterId || isSaving) return;
+  const handleConfirmSaveAsNew = async () => {
+    const timeTableName = nameDraft.trim();
+    if (!semesterId || isSaving || !timeTableName) return;
     setSaving(true);
     try {
       const created = await createTimeTableMutation.mutateAsync({
         semesterId,
-        timeTableName: `${candidate.label} (마법사 추천)`,
+        timeTableName,
       });
       await addCandidateCourses(created.id);
       mixpanelTrack.timetableWizardAction("저장", {
         save_mode: "새 시간표",
         course_count: candidate.courses.length,
       });
+      setNameModalOpen(false);
       onOpenChange(false);
-      onSaved();
+      setSavedTimetableId(created.id);
     } catch (error: any) {
+      // 이름 모달은 닫지 않는다 - 실패 원인이 대개 이름 중복이라, 사용자가 바로 고쳐 재시도할 수 있어야 한다.
       alert(error.response?.data?.msg || "시간표 저장에 실패했습니다.");
     } finally {
       setSaving(false);
@@ -100,7 +114,7 @@ const WizardSaveFlow = ({
       });
       setOverwriteConfirmOpen(false);
       onOpenChange(false);
-      onSaved();
+      setSavedTimetableId(targetTimetableId);
     } catch (error: any) {
       alert(error.response?.data?.msg || "시간표 덮어쓰기에 실패했습니다.");
     } finally {
@@ -110,7 +124,8 @@ const WizardSaveFlow = ({
 
   const handleSaveClick = () => {
     if (mode === "new") {
-      handleSaveAsNew();
+      setNameDraft(candidate.label);
+      setNameModalOpen(true);
     } else if (!targetTimetableId) {
       alert("덮어쓸 시간표를 선택해주세요.");
     } else {
@@ -188,6 +203,51 @@ const WizardSaveFlow = ({
           // Figma는 파괴적 확정 버튼을 진한 빨강 채움으로 표현 — 공용 danger variant(파스텔)는
           // 다른 화면(필터 미저장 이탈 등)과 공유하므로 그대로 두고 이 버튼만 override
           style: { background: "#dc322f", color: "#ffffff" },
+        }}
+      />
+
+      <Modal
+        isOpen={isNameModalOpen}
+        onClose={() => setNameModalOpen(false)}
+        title="시간표 이름"
+        description="새로 만들 시간표의 이름을 정해주세요."
+        secondaryButton={{ text: "취소", onClick: () => setNameModalOpen(false) }}
+        primaryButton={{
+          text: "저장",
+          variant: "brand",
+          loading: isSaving,
+          disabled: !nameDraft.trim() || isSaving,
+          onClick: handleConfirmSaveAsNew,
+        }}
+      >
+        <InputField
+          label="시간표 이름"
+          value={nameDraft}
+          onChange={setNameDraft}
+          placeholder="예: 시안 A"
+        />
+      </Modal>
+
+      <Modal
+        isOpen={savedTimetableId !== null}
+        onClose={() => setSavedTimetableId(null)}
+        title="시간표를 저장했어요"
+        description="더 많은 후보를 만들거나, 저장한 시간표를 바로 확인할 수 있어요."
+        secondaryButton={{
+          text: "더 많은 후보 생성",
+          onClick: () => {
+            setSavedTimetableId(null);
+            onGenerateMore();
+          },
+        }}
+        primaryButton={{
+          text: "시간표 보러 가기",
+          variant: "brand",
+          onClick: () => {
+            const id = savedTimetableId;
+            setSavedTimetableId(null);
+            if (id !== null) onViewTimetable(id);
+          },
         }}
       />
     </>

--- a/src/pages/mobile/timetable/MobileTimetableWizardPage.tsx
+++ b/src/pages/mobile/timetable/MobileTimetableWizardPage.tsx
@@ -7,6 +7,8 @@ import CapsuleButton from "@/components/common/CapsuleButton";
 import Badge from "@/components/common/Badge";
 import { useSemesters } from "@/hooks/useSemesters";
 import useUserStore from "@/stores/useUserStore";
+import { ROUTES } from "@/constants/routes";
+import { appBridge, supportsMultiWebView } from "@/utils/appBridgeAdapter";
 import {
   WIZARD_MAX_CREDIT_SCALE,
   WIZARD_MIN_CREDIT_SCALE,
@@ -358,9 +360,20 @@ export default function MobileTimetableWizardPage() {
           }}
           candidate={selectedCandidate}
           semesterId={semester?.id ?? null}
-          onSaved={() => {
+          // 위시리스트 등 조건은 그대로 둔 채(resetWizard 미호출) 결과만 새로 뽑는다 -
+          // 헤더의 "다시 만들기"와 동일한 동작.
+          onGenerateMore={runGeneration}
+          onViewTimetable={(timeTableId) => {
             resetWizard();
-            navigate(-1);
+            const path = `${ROUTES.TIMETABLE.ROOT}?id=${timeTableId}`;
+            // 멀티 웹뷰 앱에서는 네이티브 스택을 root로 collapse하고 그 root를
+            // 이 경로로 이동시켜야 한다(마법사는 push된 별도 웹뷰이므로 일반 SPA
+            // navigate로는 그 웹뷰 자신만 이동하고 root의 시간표 탭은 안 바뀐다).
+            if (supportsMultiWebView()) {
+              appBridge.goHome(path);
+            } else {
+              navigate(path, { replace: true });
+            }
           }}
         />
       )}


### PR DESCRIPTION
## 요약
#286 해결.

### 현재 상태 → 목표 상태
- **이름 입력 없이 자동 저장** → 새 시간표로 저장할 때 이름 입력 모달을 먼저 띄우고, 사용자가 입력한 이름으로 저장. 이름 중복 등으로 실패해도 모달이 닫히지 않아 그 자리에서 바로 다른 이름으로 재시도 가능.
- **완료 후 마법사 첫 화면으로 이동** → 저장 완료 시 "더 많은 후보 생성 / 시간표 보러 가기"를 고르는 모달 제공.
  - **더 많은 후보 생성**: `resetWizard()`를 호출하지 않고 재생성만 트리거해, 담아둔 위시리스트 강의 등 기존 조건을 그대로 유지 (헤더의 "다시 만들기"와 동일 동작).
  - **시간표 보러 가기**: `/timetable?id=[id]`로 이동. 멀티 웹뷰 지원 앱에서는 `appBridge.goHome()`으로 네이티브 스택을 root로 collapse 후 그 경로로 이동(마법사는 push된 별도 웹뷰라 일반 SPA navigate로는 root의 시간표 탭이 갱신되지 않음). 구버전 앱/브라우저는 일반 SPA navigate로 폴백.

## 변경 파일
- `src/components/mobile/timetable/wizard/WizardSaveFlow.tsx`
- `src/pages/mobile/timetable/MobileTimetableWizardPage.tsx`

## 테스트
- `npx tsc --noEmit -p .` — 이번 변경으로 인한 신규 에러 없음 (기존에도 있던 `qrcode.react` 모듈 미설치 에러 1건만 무관하게 존재)
- `eslint`(레거시 config로 실행) — 변경된 두 파일 기준 신규 에러 없음 (기존에도 있던 `catch (error: any)` 관련 에러 2건은 이번 변경 이전부터 존재)

🤖 Generated with [Claude Code](https://claude.com/claude-code)