### PR TITLE
feat: 학점계산기 저장 플로우에 GradeRecord API 연동

### DIFF
--- a/src/apis/grades.ts
+++ b/src/apis/grades.ts
@@ -1,0 +1,81 @@
+import tokenInstance from "@/apis/tokenInstance";
+import type { ApiResponse } from "@/types/common";
+import type { Term } from "@/types/timetables";
+import type { GradeRecord, GradeRecordSaveRequest } from "@/types/gradeRecords";
+import { isMockApiEnabled, mockDelay } from "@/mocks/mockFlag";
+import {
+  mockDeleteAllGradeRecords,
+  mockGetAllGradeRecords,
+  mockGetGradeRecords,
+  mockUpsertGradeRecords,
+} from "@/mocks/mockGradeStore";
+
+/**
+ * 특정 년도/학기 성적 조회
+ */
+export const getGradeRecords = async (
+  year: number,
+  term: Term,
+): Promise<GradeRecord[]> => {
+  if (isMockApiEnabled()) {
+    await mockDelay();
+    return mockGetGradeRecords(year, term);
+  }
+
+  const response = await tokenInstance.get<ApiResponse<GradeRecord[]>>(
+    "/api/grades",
+    { params: { year, term } },
+  );
+  return response.data.data ?? [];
+};
+
+/**
+ * 내 성적 전체 조회
+ */
+export const getAllGradeRecords = async (): Promise<GradeRecord[]> => {
+  if (isMockApiEnabled()) {
+    await mockDelay();
+    return mockGetAllGradeRecords();
+  }
+
+  const response =
+    await tokenInstance.get<ApiResponse<GradeRecord[]>>("/api/grades/all");
+  return response.data.data ?? [];
+};
+
+/**
+ * 특정 년도/학기 성적 저장 및 교체.
+ * 같은 년도/학기의 기존 성적은 모두 삭제된 뒤 body.records로 교체된다.
+ */
+export const upsertGradeRecords = async (
+  body: GradeRecordSaveRequest,
+): Promise<GradeRecord[]> => {
+  if (isMockApiEnabled()) {
+    await mockDelay();
+    return mockUpsertGradeRecords(body);
+  }
+
+  const response = await tokenInstance.put<ApiResponse<GradeRecord[]>>(
+    "/api/grades",
+    body,
+  );
+  return response.data.data ?? [];
+};
+
+/**
+ * 특정 년도/학기 성적 전체 삭제
+ */
+export const deleteAllGradeRecords = async (
+  year: number,
+  term: Term,
+): Promise<void> => {
+  if (isMockApiEnabled()) {
+    await mockDelay();
+    mockDeleteAllGradeRecords(year, term);
+    return;
+  }
+
+  await tokenInstance.delete<ApiResponse<null>>("/api/grades", {
+    params: { year, term },
+  });
+};

--- a/src/hooks/useGradeRecords.ts
+++ b/src/hooks/useGradeRecords.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  deleteAllGradeRecords,
+  getAllGradeRecords,
+  upsertGradeRecords,
+} from "@/apis/grades";
+import useUserStore from "@/stores/useUserStore";
+import type { Term } from "@/types/timetables";
+import type { GradeRecordSaveRequest } from "@/types/gradeRecords";
+
+export const GRADE_RECORDS_QUERY_KEY = ["gradeRecords"] as const;
+
+/**
+ * 로그인한 사용자의 전체 성적을 서버에서 불러온다. 비로그인 상태에서는 요청하지 않는다.
+ */
+export const useAllGradeRecords = (options?: { enabled?: boolean }) => {
+  const isLoggedIn = Boolean(useUserStore((state) => state.tokenInfo.accessToken));
+  const enabled = (options?.enabled ?? true) && isLoggedIn;
+
+  const query = useQuery({
+    queryKey: GRADE_RECORDS_QUERY_KEY,
+    queryFn: getAllGradeRecords,
+    enabled,
+    staleTime: 1000 * 60,
+    gcTime: 1000 * 60 * 30,
+  });
+
+  return {
+    ...query,
+    gradeRecords: query.data ?? [],
+  };
+};
+
+/**
+ * 특정 년도/학기 성적을 통째로 저장(교체)한다.
+ */
+export const useUpsertGradeRecords = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: GradeRecordSaveRequest) => upsertGradeRecords(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: GRADE_RECORDS_QUERY_KEY });
+    },
+  });
+};
+
+/**
+ * 특정 년도/학기 성적을 전체 삭제한다.
+ */
+export const useDeleteAllGradeRecords = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ year, term }: { year: number; term: Term }) =>
+      deleteAllGradeRecords(year, term),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: GRADE_RECORDS_QUERY_KEY });
+    },
+  });
+};

--- a/src/mocks/mockGradeStore.ts
+++ b/src/mocks/mockGradeStore.ts
@@ -1,0 +1,60 @@
+import type { Term } from "@/types/timetables";
+import type {
+  GradeLetter,
+  GradeRecord,
+  GradeRecordSaveRequest,
+} from "@/types/gradeRecords";
+
+// apis/grades.ts를 model 레이어에서 그대로 대체하는 인메모리 CRUD 저장소.
+// 새로고침 시 초기화되며, 실 로그인 세션 없이 저장/교체 플로우를 끝까지 검증하기 위해 존재한다.
+
+// 서버가 grade 필드로 돌려주는 내부 enum 이름 흉내(화면은 grade_value만 쓰지만
+// 응답 형태를 최대한 실제 API와 비슷하게 맞춰 둔다).
+const GRADE_ENUM_NAMES: Record<GradeLetter, string> = {
+  "A+": "A_PLUS",
+  A0: "A_ZERO",
+  "B+": "B_PLUS",
+  B0: "B_ZERO",
+  "C+": "C_PLUS",
+  C0: "C_ZERO",
+  "D+": "D_PLUS",
+  D0: "D_ZERO",
+  F: "F",
+  P: "P",
+  NP: "NP",
+};
+
+let idCounter = 1;
+let records: GradeRecord[] = [];
+
+export const mockGetGradeRecords = (year: number, term: Term): GradeRecord[] =>
+  records.filter((r) => r.year === year && r.term === term);
+
+export const mockGetAllGradeRecords = (): GradeRecord[] => records;
+
+export const mockUpsertGradeRecords = (
+  body: GradeRecordSaveRequest,
+): GradeRecord[] => {
+  const created: GradeRecord[] = body.records.map((r) => ({
+    id: idCounter++,
+    year: body.year,
+    term: body.term,
+    courseCode: r.courseCode ?? null,
+    title: r.title,
+    credit: r.credit,
+    grade: r.grade ? GRADE_ENUM_NAMES[r.grade] : null,
+    grade_value: r.grade,
+    isMajor: r.isMajor,
+    isCourseRepetition: r.isCourseRepetition,
+  }));
+
+  records = [
+    ...records.filter((r) => !(r.year === body.year && r.term === body.term)),
+    ...created,
+  ];
+  return created;
+};
+
+export const mockDeleteAllGradeRecords = (year: number, term: Term): void => {
+  records = records.filter((r) => !(r.year === year && r.term === term));
+};

--- a/src/pages/mobile/timetable/MobileGradeCalculatorPage.tsx
+++ b/src/pages/mobile/timetable/MobileGradeCalculatorPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import { useHeader } from "@/context/HeaderContext";
 import { useTimetableStore } from "@/stores/useTimetableStore";
@@ -9,6 +9,7 @@ import {
 import {
   Pencil,
   Plus,
+  Trash2,
   X,
   ChevronDown,
   ChevronUp,
@@ -22,6 +23,14 @@ import GradeImportSheet from "@/components/mobile/timetable/GradeImportSheet";
 import { isMajorCompletion } from "@/utils/parseSmartCampusGrades";
 import type { ResolvedGradeRow } from "@/types/gradeImport";
 import type { Term } from "@/types/timetables";
+import { TERM_LABELS, TERM_ORDER, formatSemester } from "@/utils/semester";
+import useUserStore from "@/stores/useUserStore";
+import {
+  useAllGradeRecords,
+  useDeleteAllGradeRecords,
+  useUpsertGradeRecords,
+} from "@/hooks/useGradeRecords";
+import type { GradeLetter, GradeRecord } from "@/types/gradeRecords";
 import {
   ResponsiveContainer,
   LineChart,
@@ -62,22 +71,71 @@ interface Subject {
   sourceTerm?: Term;
 }
 
+/** 실제 연도 + 학기. 서버 GradeRecord API의 year/term과 그대로 대응한다. */
+interface SemesterEntry {
+  year: number;
+  term: Term;
+}
+
+// SemestersData의 키는 "연도-학기"(예: "2026-FIRST") 문자열이다.
 type SemestersData = Record<string, Subject[]>;
 
 // --- Constants ---
-const SEMESTERS = [
-  "1학년 1학기",
-  "1학년 2학기",
-  "2학년 1학기",
-  "2학년 2학기",
-  "3학년 1학기",
-  "3학년 2학기",
-  "4학년 1학기",
-  "4학년 2학기",
-  "기타학기",
-];
-
 const GRADES = ["A+", "A0", "B+", "B0", "C+", "C0", "D+", "D0", "F", "P", "NP"];
+
+// --- 학기 키 헬퍼 ---
+const semesterKey = (entry: SemesterEntry): string =>
+  `${entry.year}-${entry.term}`;
+
+const parseSemesterKey = (key: string): SemesterEntry => {
+  const [yearStr, term] = key.split("-");
+  return { year: Number(yearStr), term: term as Term };
+};
+
+const compareSemesterKeys = (a: string, b: string): number => {
+  const ea = parseSemesterKey(a);
+  const eb = parseSemesterKey(b);
+  return ea.year - eb.year || TERM_ORDER[ea.term] - TERM_ORDER[eb.term];
+};
+
+const formatSemesterKeyLabel = (key: string): string => {
+  const entry = parseSemesterKey(key);
+  return formatSemester(entry.year, entry.term);
+};
+
+// 정확한 개강일 대신 대략적인 학사 일정으로 "현재 학기"를 추정한다.
+// (1~2월은 겨울학기로 보고 전년도로 취급)
+const getDefaultSemesterEntry = (): SemesterEntry => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1;
+  if (month >= 3 && month <= 6) return { year, term: "FIRST" };
+  if (month >= 7 && month <= 8) return { year, term: "SUMMER" };
+  if (month >= 9 && month <= 12) return { year, term: "SECOND" };
+  return { year: year - 1, term: "WINTER" };
+};
+
+// --- Subject <-> GradeRecord 매핑 ---
+const toGradeRecordRequest = (subject: Subject) => ({
+  courseCode: subject.courseCode || undefined,
+  title: subject.name,
+  credit: subject.credits,
+  grade: subject.grade === UNGRADED ? null : (subject.grade as GradeLetter),
+  isMajor: subject.isMajor,
+  isCourseRepetition: Boolean(subject.excluded),
+});
+
+const fromGradeRecord = (record: GradeRecord): Subject => ({
+  id: `server-${record.id}`,
+  name: record.title,
+  credits: record.credit,
+  grade: record.grade_value ?? UNGRADED,
+  isMajor: record.isMajor,
+  excluded: record.isCourseRepetition,
+  courseCode: record.courseCode ?? undefined,
+  sourceYear: record.year,
+  sourceTerm: record.term,
+});
 
 // 성적이 아직 안 나온 과목. 평점에도, 취득 학점에도 반영하지 않는다.
 const UNGRADED = "";
@@ -94,26 +152,6 @@ const GRADE_POINTS: Record<string, number> = {
   F: 0.0,
 };
 
-const DEFAULT_SUBJECTS_2_1: Subject[] = [
-  {
-    id: "1",
-    name: "디지털엔터테인먼트콘텐츠",
-    credits: 2,
-    grade: "A+",
-    isMajor: true,
-  },
-  { id: "2", name: "문학과테마기행", credits: 3, grade: "B+", isMajor: false },
-  { id: "3", name: "대학영어회화", credits: 1, grade: "C+", isMajor: false },
-  {
-    id: "4",
-    name: "멀티미디어프로그래밍",
-    credits: 2,
-    grade: "D+",
-    isMajor: true,
-  },
-  { id: "5", name: "캐릭터디자인", credits: 2, grade: "F", isMajor: true },
-];
-
 // P/NP는 평점에서 빠지고, F/NP는 취득 학점에서 빠진다. 미입력(성적 미발표)과
 // 재수강으로 취소된 과목은 둘 다 빠진다.
 const countsInGpa = (sub: Subject) =>
@@ -127,10 +165,13 @@ const isPassed = (sub: Subject) =>
   sub.grade !== "NP" &&
   sub.grade !== UNGRADED;
 
-const LOCAL_STORAGE_KEY = "intip_grade_calculator_data";
+// v2: 학기 키가 "N학년 M학기" 프리셋 라벨에서 실제 "연도-학기"로 바뀌어 예전 캐시와 호환되지 않는다.
+const LOCAL_STORAGE_KEY = "intip_grade_calculator_data_v2";
 
 const serializeGradeData = (data: SemestersData, targetCredits: number) =>
   JSON.stringify({ semestersData: data, targetCredits });
+
+const serializeSubjects = (subjects: Subject[]) => JSON.stringify(subjects);
 
 const CustomXAxisTick = (props: any) => {
   const { x, y, payload } = props;
@@ -166,8 +207,9 @@ const CustomXAxisTick = (props: any) => {
 
 export default function MobileGradeCalculatorPage() {
   // --- State ---
-  const [selectedSemester, setSelectedSemester] =
-    useState<string>("2학년 1학기");
+  const [selectedSemesterKey, setSelectedSemesterKey] = useState<
+    string | null
+  >(null);
   const [semestersData, setSemestersData] = useState<SemestersData>({});
   const [savedSemestersData, setSavedSemestersData] = useState<SemestersData>(
     {},
@@ -184,8 +226,15 @@ export default function MobileGradeCalculatorPage() {
   const [showTimetableSheet, setShowTimetableSheet] = useState<boolean>(false);
   const [showGradeImportSheet, setShowGradeImportSheet] =
     useState<boolean>(false);
+  const [showAddSemesterModal, setShowAddSemesterModal] =
+    useState<boolean>(false);
+  const [newSemesterYearInput, setNewSemesterYearInput] =
+    useState<string>("");
+  const [newSemesterTerm, setNewSemesterTerm] = useState<Term>("FIRST");
+  const [isSaving, setIsSaving] = useState<boolean>(false);
 
   const { timetables } = useTimetableStore();
+  const isLoggedIn = Boolean(useUserStore((state) => state.tokenInfo.accessToken));
 
   // --- Header Integration ---
   useHeader({
@@ -195,30 +244,64 @@ export default function MobileGradeCalculatorPage() {
   });
 
   // --- Load Data ---
+  // 로그인한 사용자는 서버(GET /api/grades/all)를 우선하고, 서버에 데이터가
+  // 없거나 비로그인이면 로컬 캐시로 폴백한다. 초기 진입 시 한 번만 반영한다.
+  const allGradeRecordsQuery = useAllGradeRecords();
+  const hasInitializedRef = useRef(false);
+
   useEffect(() => {
+    if (hasInitializedRef.current) return;
+    // 로그인 상태면 서버 조회가 끝날 때까지 기다렸다가 한 번에 반영한다
+    // (캐시 → 서버 두 번 렌더링해서 깜빡이는 걸 피하기 위함).
+    if (isLoggedIn && !allGradeRecordsQuery.isFetched) return;
+    hasInitializedRef.current = true;
+
+    let initialSemestersData: SemestersData | null = null;
+    let initialTargetCredits = 130;
+
     const cached = localStorage.getItem(LOCAL_STORAGE_KEY);
     if (cached) {
       try {
         const parsed = JSON.parse(cached);
-        const loadedSemestersData = parsed.semestersData || {};
-        const loadedTargetCredits = parsed.targetCredits || 130;
-        setSemestersData(loadedSemestersData);
-        setSavedSemestersData(loadedSemestersData);
-        setTargetCredits(loadedTargetCredits);
-        setSavedTargetCredits(loadedTargetCredits);
+        initialTargetCredits = parsed.targetCredits || 130;
+        if (!isLoggedIn) initialSemestersData = parsed.semestersData || {};
       } catch (e) {
         console.error("Failed to parse cached grades", e);
       }
-    } else {
-      // Default initial data
-      const initial: SemestersData = {
-        "2학년 1학기": DEFAULT_SUBJECTS_2_1,
-      };
-      setSemestersData(initial);
-      setSavedSemestersData(initial);
-      localStorage.setItem(LOCAL_STORAGE_KEY, serializeGradeData(initial, 130));
     }
-  }, []);
+
+    if (isLoggedIn) {
+      const serverRecords = allGradeRecordsQuery.data ?? [];
+      if (serverRecords.length > 0) {
+        const grouped: SemestersData = {};
+        serverRecords.forEach((record) => {
+          const key = semesterKey({ year: record.year, term: record.term });
+          grouped[key] = [...(grouped[key] ?? []), fromGradeRecord(record)];
+        });
+        initialSemestersData = grouped;
+      } else if (cached) {
+        try {
+          initialSemestersData = JSON.parse(cached).semestersData || {};
+        } catch {
+          initialSemestersData = {};
+        }
+      }
+    }
+
+    if (!initialSemestersData || Object.keys(initialSemestersData).length === 0) {
+      initialSemestersData = { [semesterKey(getDefaultSemesterEntry())]: [] };
+    }
+
+    setSemestersData(initialSemestersData);
+    setSavedSemestersData(initialSemestersData);
+    setTargetCredits(initialTargetCredits);
+    setSavedTargetCredits(initialTargetCredits);
+
+    const sortedKeys = Object.keys(initialSemestersData).sort(
+      compareSemesterKeys,
+    );
+    setSelectedSemesterKey(sortedKeys[sortedKeys.length - 1] ?? null);
+  }, [isLoggedIn, allGradeRecordsQuery.isFetched, allGradeRecordsQuery.data]);
 
   // --- Save Data Helper ---
   const hasChanges = useMemo(() => {
@@ -228,13 +311,83 @@ export default function MobileGradeCalculatorPage() {
     );
   }, [savedSemestersData, savedTargetCredits, semestersData, targetCredits]);
 
-  const saveToLocalStorage = () => {
+  const upsertGradeRecordsMutation = useUpsertGradeRecords();
+  const deleteAllGradeRecordsMutation = useDeleteAllGradeRecords();
+
+  const saveToLocalStorageOnly = () => {
     localStorage.setItem(
       LOCAL_STORAGE_KEY,
       serializeGradeData(semestersData, targetCredits),
     );
     setSavedSemestersData(semestersData);
     setSavedTargetCredits(targetCredits);
+  };
+
+  // 과목명이 비어 있으면 서버가 요구하는 필수값(title)을 못 채우니 저장 전에 걸러낸다.
+  const findSemesterWithBlankSubjectName = (): string | null => {
+    for (const key of Object.keys(semestersData)) {
+      if (semestersData[key].some((sub) => !sub.name.trim())) return key;
+    }
+    return null;
+  };
+
+  const handleSave = async () => {
+    const invalidKey = findSemesterWithBlankSubjectName();
+    if (invalidKey) {
+      setSelectedSemesterKey(invalidKey);
+      alert(
+        `"${formatSemesterKeyLabel(invalidKey)}"에 과목명이 비어 있는 과목이 있어요. 입력 후 다시 저장해주세요.`,
+      );
+      return;
+    }
+
+    if (!isLoggedIn) {
+      saveToLocalStorageOnly();
+      return;
+    }
+
+    const changedKeys = Object.keys(semestersData).filter(
+      (key) =>
+        serializeSubjects(semestersData[key]) !==
+        serializeSubjects(savedSemestersData[key] ?? []),
+    );
+    const removedKeys = Object.keys(savedSemestersData).filter(
+      (key) => !(key in semestersData),
+    );
+
+    if (changedKeys.length === 0 && removedKeys.length === 0) {
+      saveToLocalStorageOnly();
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await Promise.all([
+        ...changedKeys.map((key) => {
+          const entry = parseSemesterKey(key);
+          return upsertGradeRecordsMutation.mutateAsync({
+            year: entry.year,
+            term: entry.term,
+            records: semestersData[key].map(toGradeRecordRequest),
+          });
+        }),
+        ...removedKeys.map((key) =>
+          deleteAllGradeRecordsMutation.mutateAsync(parseSemesterKey(key)),
+        ),
+      ]);
+
+      localStorage.setItem(
+        LOCAL_STORAGE_KEY,
+        serializeGradeData(semestersData, targetCredits),
+      );
+      setSavedSemestersData(semestersData);
+      setSavedTargetCredits(targetCredits);
+    } catch (e) {
+      console.error("Failed to save grades to server", e);
+      alert("성적 저장에 실패했어요. 잠시 후 다시 시도해주세요.");
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const blocker = useBlocker(hasChanges);
@@ -283,17 +436,68 @@ export default function MobileGradeCalculatorPage() {
     };
   }, [hasChanges]);
 
+  // --- Semester Operations ---
+  const sortedSemesterKeys = useMemo(
+    () => Object.keys(semestersData).sort(compareSemesterKeys),
+    [semestersData],
+  );
+
+  const openAddSemesterModal = () => {
+    const def = getDefaultSemesterEntry();
+    setNewSemesterYearInput(String(def.year));
+    setNewSemesterTerm(def.term);
+    setShowAddSemesterModal(true);
+  };
+
+  const isNewSemesterValid = useMemo(() => {
+    const year = parseInt(newSemesterYearInput, 10);
+    if (Number.isNaN(year) || year < 2000 || year > 2100) return false;
+    return !(semesterKey({ year, term: newSemesterTerm }) in semestersData);
+  }, [newSemesterYearInput, newSemesterTerm, semestersData]);
+
+  const handleConfirmAddSemester = () => {
+    const year = parseInt(newSemesterYearInput, 10);
+    if (Number.isNaN(year)) return;
+    const key = semesterKey({ year, term: newSemesterTerm });
+    if (key in semestersData) return;
+
+    setSemestersData((prev) => ({ ...prev, [key]: [] }));
+    setSelectedSemesterKey(key);
+    setShowAddSemesterModal(false);
+  };
+
+  const handleDeleteSemesterEntry = (key: string) => {
+    const subjects = semestersData[key] ?? [];
+    const label = formatSemesterKeyLabel(key);
+    const confirmMessage =
+      subjects.length > 0
+        ? `"${label}"에 입력된 ${subjects.length}개 과목이 모두 삭제됩니다. 계속할까요?`
+        : `"${label}"을(를) 목록에서 삭제할까요?`;
+    if (!window.confirm(confirmMessage)) return;
+
+    setSemestersData((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+
+    if (selectedSemesterKey === key) {
+      const remaining = sortedSemesterKeys.filter((k) => k !== key);
+      setSelectedSemesterKey(remaining[remaining.length - 1] ?? null);
+    }
+  };
+
   // --- Subject Operations ---
   const currentSubjects = useMemo(() => {
-    return semestersData[selectedSemester] || [];
-  }, [semestersData, selectedSemester]);
+    return selectedSemesterKey ? semestersData[selectedSemesterKey] || [] : [];
+  }, [semestersData, selectedSemesterKey]);
 
   const updateSubjects = (newSubjects: Subject[]) => {
-    const updated = {
-      ...semestersData,
-      [selectedSemester]: newSubjects,
-    };
-    setSemestersData(updated);
+    if (!selectedSemesterKey) return;
+    setSemestersData((prev) => ({
+      ...prev,
+      [selectedSemesterKey]: newSubjects,
+    }));
   };
 
   const handleAddSubject = () => {
@@ -429,26 +633,40 @@ export default function MobileGradeCalculatorPage() {
 
   // --- SVG Graph Data ---
   const graphData = useMemo(() => {
-    const semestersWithData = SEMESTERS.map((sem) => {
-      const subjects = semestersData[sem] || [];
-      if (subjects.length === 0) return null;
-      const stats = calculateSemesterStats(subjects);
-      return { semester: sem, gpa: stats.gpa };
-    }).filter(
-      (item): item is { semester: string; gpa: number } => item !== null,
-    );
+    const semestersWithData = sortedSemesterKeys
+      .map((key) => {
+        const subjects = semestersData[key] || [];
+        if (subjects.length === 0) return null;
+        const stats = calculateSemesterStats(subjects);
+        return {
+          semesterKey: key,
+          semester: formatSemesterKeyLabel(key),
+          gpa: stats.gpa,
+        };
+      })
+      .filter(
+        (
+          item,
+        ): item is { semesterKey: string; semester: string; gpa: number } =>
+          item !== null,
+      );
 
     return semestersWithData;
-  }, [semestersData]);
+  }, [semestersData, sortedSemesterKeys]);
+
+  const selectedSemesterLabel = selectedSemesterKey
+    ? formatSemesterKeyLabel(selectedSemesterKey)
+    : "";
 
   // --- Timetable Importer ---
   const handleImportTimetable = (timetableId: number) => {
+    if (!selectedSemesterKey) return;
     const tb = timetables.find((t) => t.id === timetableId);
     if (!tb) return;
 
     if (
       window.confirm(
-        `"${tb.semester} (${tb.name})" 시간표의 과목들을 불러올까요?\n현재 학기(${selectedSemester})에 작성 중인 과목 목록은 덮어씌워집니다.`,
+        `"${tb.semester} (${tb.name})" 시간표의 과목들을 불러올까요?\n현재 학기(${selectedSemesterLabel})에 작성 중인 과목 목록은 덮어씌워집니다.`,
       )
     ) {
       const imported: Subject[] = tb.events.map((event) => {
@@ -474,10 +692,11 @@ export default function MobileGradeCalculatorPage() {
     rows: ResolvedGradeRow[],
     source: { year: number; term: Term } | null,
   ) => {
+    if (!selectedSemesterKey) return;
     if (
       currentSubjects.length > 0 &&
       !window.confirm(
-        `현재 학기(${selectedSemester})에 입력된 ${currentSubjects.length}개 과목을 불러온 ${rows.length}개 과목으로 바꿀까요?`,
+        `현재 학기(${selectedSemesterLabel})에 입력된 ${currentSubjects.length}개 과목을 불러온 ${rows.length}개 과목으로 바꿀까요?`,
       )
     ) {
       return;
@@ -671,7 +890,7 @@ export default function MobileGradeCalculatorPage() {
                 <LineChart
                   data={(() => {
                     return graphData.map((d) => {
-                      const subjects = semestersData[d.semester] || [];
+                      const subjects = semestersData[d.semesterKey] || [];
                       const stats = calculateSemesterStats(subjects);
                       return {
                         name: d.semester,
@@ -757,9 +976,19 @@ export default function MobileGradeCalculatorPage() {
 
       {/* 2. 학기별 학점계산기 메인 카드 */}
       <MainContainer>
+        {!selectedSemesterKey ? (
+          <EmptySemesterState>
+            <p>아직 추가된 학기가 없어요.</p>
+            <p className="sub">학기를 추가하고 성적을 입력해보세요.</p>
+            <CapsuleButton variant="brand" onClick={openAddSemesterModal}>
+              학기 추가
+            </CapsuleButton>
+          </EmptySemesterState>
+        ) : (
+        <>
         <SemesterSummaryHeader>
           <SemesterSelectButton onClick={() => setShowSemesterSheet(true)}>
-            <span className="semester-name">{selectedSemester}</span>
+            <span className="semester-name">{selectedSemesterLabel}</span>
             <ChevronDown size={20} className="dropdown-caret" />
           </SemesterSelectButton>
 
@@ -925,6 +1154,8 @@ export default function MobileGradeCalculatorPage() {
             <ResetButton onClick={handleResetSubjects}>초기화</ResetButton>
           </TableFooter>
         </GradeTable>
+        </>
+        )}
       </MainContainer>
 
       {/* 학기 선택 바텀 시트 */}
@@ -937,22 +1168,82 @@ export default function MobileGradeCalculatorPage() {
               <div className="title">학기 선택</div>
             </SheetHeader>
             <SheetList>
-              {SEMESTERS.map((sem) => (
-                <SheetItem
-                  key={sem}
-                  $active={sem === selectedSemester}
-                  onClick={() => {
-                    setSelectedSemester(sem);
-                    setShowSemesterSheet(false);
-                  }}
-                >
-                  {sem}
-                </SheetItem>
-              ))}
+              {sortedSemesterKeys.length === 0 ? (
+                <EmptySheetText>추가된 학기가 없습니다.</EmptySheetText>
+              ) : (
+                sortedSemesterKeys.map((key) => (
+                  <SemesterSheetRow key={key} $active={key === selectedSemesterKey}>
+                    <SemesterLabelButton
+                      $active={key === selectedSemesterKey}
+                      onClick={() => {
+                        setSelectedSemesterKey(key);
+                        setShowSemesterSheet(false);
+                      }}
+                    >
+                      {formatSemesterKeyLabel(key)}
+                    </SemesterLabelButton>
+                    <DeleteSemesterButton
+                      onClick={() => handleDeleteSemesterEntry(key)}
+                      aria-label="학기 삭제"
+                    >
+                      <Trash2 size={16} />
+                    </DeleteSemesterButton>
+                  </SemesterSheetRow>
+                ))
+              )}
+              <AddSemesterRow
+                onClick={() => {
+                  setShowSemesterSheet(false);
+                  openAddSemesterModal();
+                }}
+              >
+                <Plus size={16} />
+                <span>학기 추가</span>
+              </AddSemesterRow>
             </SheetList>
           </BottomSheet>
         </>
       )}
+
+      {/* 학기 추가 모달 */}
+      <Modal
+        isOpen={showAddSemesterModal}
+        onClose={() => setShowAddSemesterModal(false)}
+        title="학기 추가"
+        description="추가할 학기의 연도와 학기를 선택해주세요."
+        primaryButton={{
+          text: "추가",
+          variant: "brand",
+          onClick: handleConfirmAddSemester,
+          disabled: !isNewSemesterValid,
+        }}
+        secondaryButton={{
+          text: "취소",
+          onClick: () => setShowAddSemesterModal(false),
+        }}
+      >
+        <InputField
+          label="연도"
+          value={newSemesterYearInput}
+          onChange={(v) => setNewSemesterYearInput(v.replace(/\D/g, "").slice(0, 4))}
+          placeholder="예: 2026"
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+        />
+        <TermPickerRow>
+          {(Object.keys(TERM_LABELS) as Term[]).map((term) => (
+            <TermPickerButton
+              key={term}
+              type="button"
+              $active={term === newSemesterTerm}
+              onClick={() => setNewSemesterTerm(term)}
+            >
+              {TERM_LABELS[term]}
+            </TermPickerButton>
+          ))}
+        </TermPickerRow>
+      </Modal>
 
       {/* 시간표 불러오기 바텀 시트 */}
       {showTimetableSheet && (
@@ -988,7 +1279,7 @@ export default function MobileGradeCalculatorPage() {
       <GradeImportSheet
         isOpen={showGradeImportSheet}
         onClose={() => setShowGradeImportSheet(false)}
-        targetSemesterLabel={selectedSemester}
+        targetSemesterLabel={selectedSemesterLabel}
         onApply={handleApplyImportedGrades}
       />
 
@@ -996,8 +1287,9 @@ export default function MobileGradeCalculatorPage() {
         <CapsuleButton
           variant="primary"
           fullWidth
-          disabled={!hasChanges}
-          onClick={saveToLocalStorage}
+          disabled={!hasChanges || isSaving}
+          loading={isSaving}
+          onClick={handleSave}
           style={{ width: "fit-content" }}
         >
           저장
@@ -1656,4 +1948,113 @@ const EmptySheetText = styled.div`
   font-size: 14px;
   color: var(--text-tertiary, #8b95a1);
   padding: 32px 16px;
+`;
+
+// 학기 선택 시트의 학기 항목(라벨 + 삭제 버튼)
+const SemesterSheetRow = styled.div<{ $active?: boolean }>`
+  display: flex;
+  align-items: center;
+  border-radius: 12px;
+  background-color: ${({ $active }) =>
+    $active ? "var(--bg-brand-subtle, #eff6ff)" : "transparent"};
+`;
+
+const SemesterLabelButton = styled.button<{ $active?: boolean }>`
+  flex: 1;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  padding: 0 8px 0 16px;
+  background: none;
+  border: none;
+  text-align: left;
+  font-size: 15px;
+  color: ${({ $active }) =>
+    $active ? "var(--text-brand, #0061ff)" : "var(--text-secondary, #333d4b)"};
+  font-weight: ${({ $active }) => ($active ? 600 : 400)};
+  cursor: pointer;
+  outline: none;
+`;
+
+const DeleteSemesterButton = styled.button`
+  width: 40px;
+  height: 52px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-tertiary, #8b95a1);
+  cursor: pointer;
+  outline: none;
+
+  &:hover {
+    color: var(--text-error, #ef4444);
+  }
+`;
+
+const AddSemesterRow = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 52px;
+  padding: 0 16px;
+  margin-top: 4px;
+  border: none;
+  border-top: 1px solid var(--border-default, #e5e8eb);
+  background: none;
+  color: var(--text-brand, #0061ff);
+  font-size: 15px;
+  font-weight: 500;
+  cursor: pointer;
+  outline: none;
+`;
+
+// 학기 추가 모달의 학기(FIRST/SUMMER/SECOND/WINTER) 선택 버튼 그룹
+const TermPickerRow = styled.div`
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+`;
+
+const TermPickerButton = styled.button<{ $active: boolean }>`
+  flex: 1;
+  min-width: 70px;
+  padding: 10px 0;
+  border-radius: 10px;
+  border: 1px solid
+    ${({ $active }) =>
+      $active ? "var(--border-brand, #0061ff)" : "var(--border-default, #e5e8eb)"};
+  background-color: ${({ $active }) =>
+    $active ? "var(--bg-brand-subtle, #eff6ff)" : "var(--bg-base, #ffffff)"};
+  color: ${({ $active }) =>
+    $active ? "var(--text-brand, #0061ff)" : "var(--text-secondary, #333d4b)"};
+  font-size: 14px;
+  font-weight: ${({ $active }) => ($active ? 600 : 400)};
+  cursor: pointer;
+  outline: none;
+`;
+
+// 학기가 하나도 없을 때 메인 카드에 보여주는 빈 상태
+const EmptySemesterState = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px 20px;
+  text-align: center;
+
+  p {
+    margin: 0;
+    font-size: 14px;
+    color: var(--text-secondary, #333d4b);
+  }
+
+  .sub {
+    font-size: 13px;
+    color: var(--text-tertiary, #8b95a1);
+    margin-bottom: 8px;
+  }
 `;

--- a/src/pages/mobile/timetable/MobileGradeCalculatorPage.tsx
+++ b/src/pages/mobile/timetable/MobileGradeCalculatorPage.tsx
@@ -40,6 +40,7 @@ import {
   ReferenceLine,
 } from "recharts";
 import { backHandler } from "@/utils/backHandler";
+import type { ClassItem } from "@/components/mobile/timetable/TimetableGrid";
 
 // --- Types ---
 interface Subject {
@@ -172,6 +173,20 @@ const serializeGradeData = (data: SemestersData, targetCredits: number) =>
   JSON.stringify({ semestersData: data, targetCredits });
 
 const serializeSubjects = (subjects: Subject[]) => JSON.stringify(subjects);
+
+// tb.events는 "미팅(요일별 시간 블록) 1개당 1행"이라 주 2회 이상 만나는 과목은
+// 이벤트가 여러 개로 쪼개져 있다. itemId(같은 요소면 동일)로 묶어 과목당 하나만 남긴다.
+// 커스텀 일정(isCustom)은 강의가 아니므로 제외한다.
+const getUniqueCourseEvents = (events: ClassItem[]): ClassItem[] => {
+  const byItemId = new Map<number | string, ClassItem>();
+  events
+    .filter((event) => !event.isCustom)
+    .forEach((event) => {
+      const key = event.itemId ?? event.id;
+      if (!byItemId.has(key)) byItemId.set(key, event);
+    });
+  return Array.from(byItemId.values());
+};
 
 const CustomXAxisTick = (props: any) => {
   const { x, y, payload } = props;
@@ -664,23 +679,30 @@ export default function MobileGradeCalculatorPage() {
     const tb = timetables.find((t) => t.id === timetableId);
     if (!tb) return;
 
+    const courseEvents = getUniqueCourseEvents(tb.events);
+
+    if (courseEvents.length === 0) {
+      alert("이 시간표에는 불러올 과목이 없어요.");
+      return;
+    }
+
     if (
       window.confirm(
-        `"${tb.semester} (${tb.name})" 시간표의 과목들을 불러올까요?\n현재 학기(${selectedSemesterLabel})에 작성 중인 과목 목록은 덮어씌워집니다.`,
+        `"${tb.semester} (${tb.name})" 시간표의 과목 ${courseEvents.length}개를 불러올까요?\n현재 학기(${selectedSemesterLabel})에 작성 중인 과목 목록은 덮어씌워집니다.`,
       )
     ) {
-      const imported: Subject[] = tb.events.map((event) => {
-        // Estimate credits based on class hours (endTime - startTime)
-        // Usually, 2 hours = 2 credits, 3 hours = 3 credits, etc.
-        const hours = Math.max(1, event.endTime - event.startTime);
-        return {
-          id: `${Date.now()}-${Math.random()}`,
-          name: event.name,
-          credits: hours,
-          grade: "A+",
-          isMajor: false,
-        };
-      });
+      const imported: Subject[] = courseEvents.map((event) => ({
+        id: `${Date.now()}-${Math.random()}`,
+        name: event.name,
+        // 개설강의에 등록된 실제 학점을 쓴다. 값이 없는 예외적인 경우에만 강의
+        // 시간(끝-시작)으로 대략 추정한다.
+        credits:
+          event.credits ?? Math.max(1, Math.round(event.endTime - event.startTime)),
+        grade: "A+",
+        isMajor: false,
+        courseCode: event.courseId,
+        courseId: event.numericCourseId ?? null,
+      }));
 
       updateSubjects(imported);
       setShowTimetableSheet(false);
@@ -1266,7 +1288,9 @@ export default function MobileGradeCalculatorPage() {
                     <div className="timetable-info">
                       <span className="semester">{tb.semester}</span>
                       <span className="name">{tb.name}</span>
-                      <span className="count">({tb.events.length}개 과목)</span>
+                      <span className="count">
+                        ({getUniqueCourseEvents(tb.events).length}개 과목)
+                      </span>
                     </div>
                   </SheetItem>
                 ))

--- a/src/types/gradeRecords.ts
+++ b/src/types/gradeRecords.ts
@@ -1,0 +1,52 @@
+import type { Term } from "@/types/timetables";
+
+/**
+ * 성적 등급. 서버 응답의 `grade_value`, 요청 바디의 `grade`가 공통으로 쓰는 표기.
+ * (서버 응답의 `grade` 필드는 "B_PLUS" 같은 내부 enum 이름이라 화면에는 안 쓴다.)
+ */
+export type GradeLetter =
+  | "A+"
+  | "A0"
+  | "B+"
+  | "B0"
+  | "C+"
+  | "C0"
+  | "D+"
+  | "D0"
+  | "F"
+  | "P"
+  | "NP";
+
+/** GET /api/grades, /api/grades/all, PUT 계열 응답에 담기는 성적 레코드 1건. */
+export interface GradeRecord {
+  id: number;
+  year: number;
+  term: Term;
+  courseCode: string | null;
+  title: string;
+  credit: number;
+  /** 서버 내부 enum 이름(예: "B_PLUS"). 화면 표시에는 grade_value를 쓴다. */
+  grade: string | null;
+  /** 화면 표기와 동일한 등급 문자열(예: "B+"). 성적 미발표 과목은 null. */
+  grade_value: GradeLetter | null;
+  isMajor: boolean;
+  /** 재수강으로 성적이 취소된 과목이면 true. */
+  isCourseRepetition: boolean;
+}
+
+/** PUT /api/grades 요청 바디의 records[] 항목 하나. */
+export interface GradeRecordRequest {
+  courseCode?: string;
+  title: string;
+  credit: number;
+  grade: GradeLetter | null;
+  isMajor: boolean;
+  isCourseRepetition: boolean;
+}
+
+/** PUT /api/grades 요청 바디. 같은 year/term의 기존 성적을 전부 지우고 교체한다. */
+export interface GradeRecordSaveRequest {
+  year: number;
+  term: Term;
+  records: GradeRecordRequest[];
+}


### PR DESCRIPTION
## 요약

학점계산기(`MobileGradeCalculatorPage`)의 저장 플로우를 서버 `GradeRecord` API(`GET /api/grades/all`, `PUT /api/grades`, `DELETE /api/grades`)에 연동합니다. 지금까지는 성적이 `localStorage`에만 저장돼서 기기를 바꾸면 사라졌습니다.

Closes #288 (걸림돌·설계 결정, 상세 구현 내용은 이슈 코멘트 참고)

## 주요 변경

- **학기 모델 교체**: `"1학년 1학기"` 같은 프리셋 라벨 → 실제 연도+학기(FIRST/SUMMER/SECOND/WINTER) 선택. 학기 선택 시트에서 직접 추가/삭제.
- **서버 동기화**: 로그인 시 진입할 때 `GET /api/grades/all`로 불러오고, 서버에 데이터가 없거나 비로그인/오프라인이면 로컬 캐시로 폴백.
- **저장**: 바뀐 학기만 `PUT /api/grades`로 upsert, 통째로 삭제된 학기는 `DELETE /api/grades`로 반영. 실패 시 alert 안내 후 재시도 가능.
- 신규: `src/types/gradeRecords.ts`, `src/apis/grades.ts`, `src/hooks/useGradeRecords.ts`, `src/mocks/mockGradeStore.ts` (기존 `timetables` 계열과 동일한 패턴).
- `localStorage` 캐시 키를 `intip_grade_calculator_data` → `intip_grade_calculator_data_v2`로 변경(학기 키 스키마가 바뀌어 예전 캐시와 호환 안 됨).

## 스코프에서 뺀 것

- 개별 성적 수정/삭제(`PUT·DELETE /api/grades/{gradeRecordId}`) — 화면이 항상 학기 전체를 교체 저장하는 흐름이라 불필요.

자세한 배경과 설계 결정 과정은 #288 코멘트에 정리했습니다.

## 테스트

- [x] `npm run build` (`tsc && vite build`) 통과
- [ ] `npm run lint` — `main`에서도 동일하게 실패하는 기존 이슈(ESLint 9 + `.eslintrc.cjs` 설정 불일치)라 이 PR과 무관합니다.
- [ ] 실제 로그인 세션으로 저장/새로고침 왕복 QA — 리뷰 시 확인 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
