### PR TITLE
fix: 카카오톡 등 인앱 브라우저/웹뷰 접속 시 백화 현상 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,8 +63,15 @@
           );
         }
 
+        var initialToken = "";
+        try {
+          initialToken = localStorage.getItem(STORAGE_KEY);
+        } catch (error) {
+          console.warn("FCM 토큰 읽기 실패", error);
+        }
+
         window.__INTIP_FCM_BOOTSTRAP__ = {
-          token: normalizeToken(localStorage.getItem(STORAGE_KEY)),
+          token: normalizeToken(initialToken),
           receivedAt: Date.now(),
         };
 

--- a/src/apis/tokenInstance.ts
+++ b/src/apis/tokenInstance.ts
@@ -21,11 +21,13 @@ let refreshPromise: Promise<string> | null = null;
 // 만료 안내는 로그아웃 1회당 한 번만. 다시 로그인하면 아래 subscribe에서 풀린다.
 let hasNotifiedExpiry = false;
 
+import { safeLocalStorage } from "@/utils/safeStorage";
+
 const clearAuth = () => {
   resetMixpanel();
   useUserStore.getState().setTokenInfo({ ...EMPTY_TOKEN_INFO });
-  localStorage.removeItem("tokenInfo");
-  localStorage.removeItem("fcmToken");
+  safeLocalStorage.removeItem("tokenInfo");
+  safeLocalStorage.removeItem("fcmToken");
 };
 
 const notifyExpiredOnce = () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,13 +21,17 @@ const queryClient = new QueryClient({
   },
 });
 
-// RN 멀티 웹뷰 환경에서 같은 오리진의 다른 웹뷰(또는 브라우저 탭)와 쿼리
-// 캐시를 동기화한다. broadcast-channel(pubkey) 기반이라 BroadcastChannel
-// 미지원/제한 환경에서도 자체적으로 localStorage/IndexedDB 등으로 폴백한다.
-broadcastQueryClient({
-  queryClient,
-  broadcastChannel: "query-cache-sync",
-});
+try {
+  // RN 멀티 웹뷰 환경에서 같은 오리진의 다른 웹뷰(또는 브라우저 탭)와 쿼리
+  // 캐시를 동기화한다. broadcast-channel(pubkey) 기반이라 BroadcastChannel
+  // 미지원/제한 환경에서도 자체적으로 localStorage/IndexedDB 등으로 폴백한다.
+  broadcastQueryClient({
+    queryClient,
+    broadcastChannel: "query-cache-sync",
+  });
+} catch (e) {
+  console.warn("broadcastQueryClient initialization skipped or failed:", e);
+}
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <>

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -5,6 +5,8 @@ import { identifyUser } from "@/utils/mixpanel";
 import { bridgeChannel } from "@/utils/bridgeChannel";
 import { broadcastSync } from "@/stores/middleware/broadcastSync";
 
+import { safeLocalStorage } from "@/utils/safeStorage";
+
 interface UserState {
   tokenInfo: TokenInfo;
   userInfo: UserInfo;
@@ -14,7 +16,7 @@ interface UserState {
 }
 
 const getInitialToken = () => {
-  const stored = localStorage.getItem("tokenInfo");
+  const stored = safeLocalStorage.getItem("tokenInfo");
   if (stored) {
     try {
       return JSON.parse(stored);
@@ -45,7 +47,7 @@ const useUserStore = create<UserState>()(
     partialize: (state) => ({ tokenInfo: state.tokenInfo, userInfo: state.userInfo }),
     onReceive: (partial) => {
       if (partial.tokenInfo) {
-        localStorage.setItem("tokenInfo", JSON.stringify(partial.tokenInfo));
+        safeLocalStorage.setItem("tokenInfo", JSON.stringify(partial.tokenInfo));
       }
     },
   })((set) => ({
@@ -55,7 +57,7 @@ const useUserStore = create<UserState>()(
 
     setTokenInfo: (tokenInfo, options) => {
       set(() => ({ tokenInfo }));
-      localStorage.setItem("tokenInfo", JSON.stringify(tokenInfo));
+      safeLocalStorage.setItem("tokenInfo", JSON.stringify(tokenInfo));
 
     // 네이티브 셸(intip-mobile-app)로 JWT를 미러링해 SecureStore에 보관시킨다 —
     // 백그라운드 FCM 토큰 등록 등 네이티브가 웹뷰 없이 자체적으로 API를 호출해야

--- a/src/utils/getMobilePlatform.ts
+++ b/src/utils/getMobilePlatform.ts
@@ -21,18 +21,13 @@ export function getAppEnvironmentStatus(): AppEnvironmentStatus {
   if (hasReactNativeWebView()) return "NEW_APP";
 
   const userAgent = navigator.userAgent || "";
+  const hasOfficialUaTag = userAgent.includes("INTIPApp");
 
-  // 플랫폼 판별은 UA가 아니라 "주입된 브릿지 객체"로 한다.
-  // 네이티브 앱은 iOS/Android 공통으로 UA에 "INTIPApp" 접미사를 붙이므로
-  // (User-Agent 규격, 양 플랫폼 공통), UA의 "INTIPApp" 포함 여부를 안드로이드
-  // 신호로 사용하면 iOS 앱이 안드로이드 분기로 잘못 빠져 항상 OLD_APP으로 오판된다.
   const isAndroidBridgeExists = typeof window.AndroidBridge !== "undefined";
   const isIOSBridgeExists =
     typeof window.webkit?.messageHandlers?.requestAppUpdate !== "undefined";
 
-  // 1. iOS 공식 앱 판정 (AndroidBridge가 없고 webkit 브릿지가 존재하는 경우)
-  // 구버전 iOS 앱도 window.webkit.messageHandlers.requestAppUpdate는 가지고 있고,
-  // 신버전(멀티 웹뷰) iOS 앱만 navigateTo 핸들러를 노출한다.
+  // 1. iOS 공식 앱 판정 (AndroidBridge가 없고, 인팁 iOS 메시지 핸들러가 존재하는 경우)
   if (!isAndroidBridgeExists && isIOSBridgeExists) {
     return typeof window.webkit?.messageHandlers?.navigateTo !== "undefined"
       ? "NEW_APP"
@@ -41,8 +36,7 @@ export function getAppEnvironmentStatus(): AppEnvironmentStatus {
 
   // 2. 안드로이드 공식 앱 판정
   // AndroidBridge 객체가 주입되었거나, (브릿지 주입 전 타이밍 대비) UA에 INTIPApp이 포함된 경우.
-  // 신버전 안드로이드 앱은 navigateTo 함수가 존재한다.
-  if (isAndroidBridgeExists || userAgent.includes("INTIPApp")) {
+  if (isAndroidBridgeExists || (hasOfficialUaTag && !/iPhone|iPad|iPod/i.test(userAgent))) {
     return typeof window.AndroidBridge?.navigateTo === "function"
       ? "NEW_APP"
       : "OLD_APP";

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -1,0 +1,35 @@
+/**
+ * 카카오톡, 인스타그램 등 일부 인앱 브라우저나 개인정보 보안 설정이 강화된 웹뷰 환경에서
+ * localStorage 접근 시 SecurityError (DOMException)가 발생할 수 있습니다.
+ * 이에 대비해 안전하게 localStorage에 읽기/쓰기/삭제를 수행하는 헬퍼 함수입니다.
+ */
+
+export const safeLocalStorage = {
+  getItem(key: string): string | null {
+    try {
+      if (typeof window === "undefined" || !window.localStorage) return null;
+      return localStorage.getItem(key);
+    } catch (e) {
+      console.warn(`[safeLocalStorage] Failed to get item "${key}":`, e);
+      return null;
+    }
+  },
+
+  setItem(key: string, value: string): void {
+    try {
+      if (typeof window === "undefined" || !window.localStorage) return;
+      localStorage.setItem(key, value);
+    } catch (e) {
+      console.warn(`[safeLocalStorage] Failed to set item "${key}":`, e);
+    }
+  },
+
+  removeItem(key: string): void {
+    try {
+      if (typeof window === "undefined" || !window.localStorage) return;
+      localStorage.removeItem(key);
+    } catch (e) {
+      console.warn(`[safeLocalStorage] Failed to remove item "${key}":`, e);
+    }
+  },
+};


### PR DESCRIPTION
- localStorage SecurityError 예외 방지를 위한 safeLocalStorage 도입 및 index.html 가드 적용

- iOS 인앱 웹뷰에서 공식 앱으로 잘못 판정되던 getAppEnvironmentStatus 로직 보완

- BroadcastChannel 미지원 웹뷰에서 broadcastQueryClient 예외 처리