### PR TITLE
fix: 강의실 위치 보기가 캠퍼스 지도에서 해당 건물을 검색/포커스하도록 수정 (#274)

### DIFF
--- a/src/components/map/utils/findCampusPlaceByRoom.ts
+++ b/src/components/map/utils/findCampusPlaceByRoom.ts
@@ -1,0 +1,47 @@
+import { Place, places } from "../DB";
+
+/**
+ * 시간표 강의실 표기(예: "07-407", "12-402", "7호관 502호")에서
+ * 건물 번호(호관)를 추출한다.
+ *
+ * `places`(학교 탭) DB는 건물 단위로만 좌표를 가지고 있어 호실 단위 검색은
+ * 불가능하다. 대신 강의실 코드 맨 앞의 건물 번호를 뽑아 해당 건물 마커를
+ * 찾아주는 것으로 "검색/포커스"를 구현한다.
+ */
+export function extractBuildingKey(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  // "18-1호관" / "18-2호관" / "18-3호관" 처럼 건물 번호 자체에 하이픈이
+  // 들어가는 예외 케이스를 먼저 확인한다.
+  const specialMatch = trimmed.match(/^(18-[123])\s*호관/);
+  if (specialMatch) {
+    return specialMatch[1];
+  }
+
+  // 이미 "n호관" 형식으로 표기된 경우 (예: "7호관 502호")
+  const nameMatch = trimmed.match(/(\d{1,2})\s*호관/);
+  if (nameMatch) {
+    return nameMatch[1];
+  }
+
+  // "07-407", "7-407" 같은 강의실 코드에서 앞자리 건물 번호를 추출한다.
+  const codeMatch = trimmed.match(/^0*(\d{1,2})[\s-]\d/);
+  if (codeMatch) {
+    return codeMatch[1];
+  }
+
+  return null;
+}
+
+/** 강의실 표기 문자열로 캠퍼스맵의 건물 Place를 찾는다. 못 찾으면 null. */
+export function findCampusPlaceByRoom(raw: string): Place | null {
+  const key = extractBuildingKey(raw);
+  if (!key) {
+    return null;
+  }
+
+  return places.find((place) => place.location === `${key}호관`) ?? null;
+}

--- a/src/components/mobile/timetable/ClassDetailBottomSheet.tsx
+++ b/src/components/mobile/timetable/ClassDetailBottomSheet.tsx
@@ -291,9 +291,11 @@ export default function ClassDetailBottomSheet({
                       <RoomMapButton
                         type="button"
                         onClick={() => {
-                          navigate(ROUTES.BOARD.CAMPUS, {
-                            state: { search: roomVal },
-                          });
+                          // 새 웹뷰로 열려도(멀티 웹뷰 앱) 값이 유실되지 않도록
+                          // router state가 아니라 URL 쿼리로 전달한다 (#274).
+                          navigate(
+                            `${ROUTES.BOARD.CAMPUS}?search=${encodeURIComponent(roomVal)}`,
+                          );
                           onOpenChange(false);
                         }}
                       >

--- a/src/pages/mobile/MobileCampusPage.tsx
+++ b/src/pages/mobile/MobileCampusPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 
 import { postApiLogs } from "@/apis/members";
@@ -9,6 +9,7 @@ import {
   BOTTOM_SHEET_HEIGHT,
   TabType,
 } from "@/components/map/constants/mapConfig";
+import { findCampusPlaceByRoom } from "@/components/map/utils/findCampusPlaceByRoom";
 import { useHeader } from "@/context/HeaderContext";
 import { DESKTOP_MEDIA } from "@/styles/responsive";
 
@@ -57,6 +58,8 @@ export default function MobileCampusPage() {
   };
 
   const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const roomSearchQuery = searchParams.get("search");
 
   const isCampus = useMemo(
     () => location.pathname.includes("/campus"),
@@ -115,6 +118,27 @@ export default function MobileCampusPage() {
 
     void logApi();
   }, [isCampus]);
+
+  // 강의 상세에서 "강의실 위치 보기"로 진입한 경우(?search=) 해당 건물을
+  // 학교 탭에서 찾아 포커스한다. 호실 단위 좌표는 없으므로 건물 단위로
+  // 검색/포커스한다 (#274).
+  useEffect(() => {
+    if (!isCampus || !roomSearchQuery) {
+      return;
+    }
+
+    const place = findCampusPlaceByRoom(roomSearchQuery);
+    if (!place) {
+      return;
+    }
+
+    setSelectedTab("학교");
+    handleMarkerClick(place.location, {
+      X: Number(place.latitude),
+      Y: Number(place.longitude),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isCampus, roomSearchQuery]);
 
   useLayoutEffect(() => {
     if (!isCampus || typeof window === "undefined") {


### PR DESCRIPTION
## 요약

#274 에서 지적된 대로, 시간표 강의 상세의 "강의실 위치 보기" 버튼이 캠퍼스 지도를 열기만 하고 검색/포커스를 하지 않던 문제를 수정합니다.

## 변경 사항

1. **`ClassDetailBottomSheet.tsx`**: `navigate(ROUTES.BOARD.CAMPUS, { state: { search: roomVal } })` → `navigate(`${ROUTES.BOARD.CAMPUS}?search=${encodeURIComponent(roomVal)}`)`
   - router `state`는 새 웹뷰로 열리는 순간(`router.tsx`의 멀티 웹뷰 가로채기, `NavigateToPayload`에 `path`/`url`만 존재) 유실되므로, URL 쿼리로 전달하도록 변경했습니다. 새로고침·공유 링크에도 동일하게 동작합니다.

2. **`MobileCampusPage.tsx`**: `useSearchParams()`로 `?search=` 값을 읽어, 학교 탭에서 해당 건물 마커를 찾아 `setSelectedTab("학교")` + 마커 오픈/포커스(panTo)를 수행하는 effect를 추가했습니다.

3. **`src/components/map/utils/findCampusPlaceByRoom.ts`** (신규): 강의실 코드(`"07-407"`, `"12-402"` 등)에서 건물 번호(호관)를 추출해 `places` DB에서 해당 건물 Place를 찾는 순수 함수 `findCampusPlaceByRoom` / `extractBuildingKey`를 추가했습니다.
   - `places` DB는 건물 단위 좌표만 가지고 있어 호실 단위 좌표는 없습니다. 따라서 "검색/포커스"는 건물 단위로 동작합니다(예: "07-407" → "7호관" 마커 오픈 + panTo).
   - `18-1호관`/`18-2호관`/`18-3호관`처럼 건물 번호 자체에 하이픈이 들어가는 예외도 처리했습니다.
   - 건물 번호를 추출할 수 없는 값(예: "체육관")은 매칭되는 Place가 없어 지도만 기본 상태로 열립니다.

## 확인

- `tsc && vite build` 통과
- 변경 파일에 대해 `eslint` 실행 시 신규 코드는 오류 없음 (해당 파일들의 기존 pre-existing 오류 4건은 `dev` 기준에도 동일하게 존재하는, 이번 변경과 무관한 이슈입니다 — repo의 `npm run lint`가 ESLint 9 flat-config 미비로 현재 실행 자체가 되지 않는 별도 환경 이슈도 확인했습니다)

Closes #274

https://claude.ai/code/session_01W9CCX4CmknmYt6jF3Boy6c