### PR TITLE
refactor: 성적 붙여넣기 시트에서 '성적을 받은 학기' 선택 UI 제거

### DIFF
--- a/src/components/mobile/timetable/GradeImportSheet.tsx
+++ b/src/components/mobile/timetable/GradeImportSheet.tsx
@@ -7,7 +7,6 @@ import { useCourses } from "@/hooks/useCourses";
 import useUserStore from "@/stores/useUserStore";
 import { parseSmartCampusGrades } from "@/utils/parseSmartCampusGrades";
 import { resolveGradeCourses } from "@/utils/resolveGradeCourses";
-import { formatSemester } from "@/utils/semester";
 import type {
   GradeMatchStatus,
   ParsedGradeSheet,
@@ -49,8 +48,10 @@ export default function GradeImportSheet({
     null,
   );
   const [isResolving, setIsResolving] = useState(false);
-  const [sourceYear, setSourceYear] = useState<number | null>(null);
-  const [sourceTerm, setSourceTerm] = useState<Term | null>(null);
+  const [detectedSemester, setDetectedSemester] = useState<{
+    year: number;
+    term: Term;
+  } | null>(null);
 
   const { semesters } = useSemesters();
   // 과목명 매칭용 전 학과 Course 목록. 시트를 열 때만 받아온다(3천여 건, 한 번에 옴).
@@ -66,20 +67,20 @@ export default function GradeImportSheet({
     setParsed(null);
     setResolvedRows(null);
     setIsResolving(false);
-    setSourceYear(null);
-    setSourceTerm(null);
+    setDetectedSemester(null);
   }, [isOpen]);
 
-  // 학기를 고르지 않았으면 가장 최근 학기를 기본값으로 쓴다.
+  // 붙여넣은 텍스트에서 학기를 못 읽었으면 가장 최근 학기를 쓴다. 이 학기는 학수번호로
+  // 개설강의를 되짚을 때만 쓰이는데, 학수번호는 개설이 아니라 과목의 식별자라 그 과목이
+  // 열린 학기면 어느 학기로 조회하든 같은 courseId가 나온다. 그래서 사용자에게 고르게
+  // 하지 않는다.
   const effectiveSemester = useMemo(() => {
-    if (sourceYear !== null && sourceTerm !== null) {
-      return { year: sourceYear, term: sourceTerm };
-    }
+    if (detectedSemester) return detectedSemester;
     if (semesters.length > 0) {
       return { year: semesters[0].year, term: semesters[0].term };
     }
     return null;
-  }, [semesters, sourceTerm, sourceYear]);
+  }, [detectedSemester, semesters]);
 
   const handleParse = async () => {
     const result = parseSmartCampusGrades(text);
@@ -93,8 +94,7 @@ export default function GradeImportSheet({
     // 붙여넣은 텍스트에 "2026년 1학기 과목별 성적" 제목이 같이 왔다면 그 학기를 쓴다.
     const semester = result.detectedSemester ?? effectiveSemester;
     if (result.detectedSemester) {
-      setSourceYear(result.detectedSemester.year);
-      setSourceTerm(result.detectedSemester.term);
+      setDetectedSemester(result.detectedSemester);
     }
 
     setIsResolving(true);
@@ -181,34 +181,6 @@ export default function GradeImportSheet({
                 autoCapitalize="off"
                 autoCorrect="off"
               />
-
-              {semesters.length > 0 && (
-                <FieldBlock>
-                  <FieldLabel>성적을 받은 학기</FieldLabel>
-                  <ChipRow>
-                    {semesters.map((semester) => {
-                      const active =
-                        effectiveSemester?.year === semester.year &&
-                        effectiveSemester?.term === semester.term;
-                      return (
-                        <Chip
-                          key={semester.id}
-                          $active={active}
-                          onClick={() => {
-                            setSourceYear(semester.year);
-                            setSourceTerm(semester.term);
-                          }}
-                        >
-                          {formatSemester(semester.year, semester.term)}
-                        </Chip>
-                      );
-                    })}
-                  </ChipRow>
-                  <FieldHint>
-                    과목코드를 개설강의와 연결할 때 쓰는 학기예요.
-                  </FieldHint>
-                </FieldBlock>
-              )}
             </>
           ) : (
             <>
@@ -436,45 +408,6 @@ const PasteArea = styled.textarea`
     color: var(--text-disabled, #b0b8c1);
     white-space: pre;
   }
-`;
-
-const FieldBlock = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`;
-
-const FieldLabel = styled.span`
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text-secondary, #333d4b);
-`;
-
-const FieldHint = styled.span`
-  font-size: 12px;
-  color: var(--text-tertiary, #8b95a1);
-`;
-
-const ChipRow = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-`;
-
-const Chip = styled.button<{ $active: boolean }>`
-  border-radius: 999px;
-  padding: 7px 14px;
-  font-size: 13px;
-  cursor: pointer;
-  outline: none;
-  border: 1px solid
-    ${({ $active }) =>
-      $active ? "var(--border-brand, #0061ff)" : "var(--border-default, #e5e8eb)"};
-  background-color: ${({ $active }) =>
-    $active ? "var(--bg-brand-subtle, #eff6ff)" : "transparent"};
-  color: ${({ $active }) =>
-    $active ? "var(--text-brand, #0061ff)" : "var(--text-secondary, #333d4b)"};
-  font-weight: ${({ $active }) => ($active ? 600 : 400)};
 `;
 
 const SummaryLine = styled.div`


### PR DESCRIPTION
## 왜

성적 붙여넣기 시트의 **"성적을 받은 학기"** 칩이 실제로 결과를 바꾸는 경우가 거의 없어서 제거합니다.

- 이 값은 `resolveGradeCourses`의 **2단계에서만** 쓰입니다. 1단계 과목명 매칭으로 후보가 1건으로 확정된 행(`MATCHED_BY_TITLE`)은 건너뛰고, 남은 행만 `searchCourseOfferings(year, term, courseCode)`로 되짚습니다. 평점·학점 계산이나 "어느 학기 탭에 들어갈지"(그건 계산기의 `selectedSemester`)와는 무관합니다.
- 그 되짚기도 **학수번호 완전일치**로만 확정하는데, 학수번호는 개설(학기)이 아니라 **과목의 식별자**입니다. 그 과목이 열린 학기면 어느 학기로 조회하든 같은 `courseId`가 나오므로 "성적을 받은 그 학기"일 필요가 없습니다.
- 칩 목록은 `GET /api/semesters`가 주는 학기 = 서버에 개설강의가 있는 학기뿐입니다. 지난 학기 성적을 붙여넣어도 해당 학기는 목록에 없어 고를 수조차 없었고, 고른 학기에 그 과목이 없으면 조용히 `UNMATCHED`로 남습니다(붙여넣기 자체는 정상 진행).

즉 사용자에게 판단을 요구하는 값인데, 잘 골라도 이득이 없고 잘못 골라도 손해가 없는 입력이었습니다.

## 무엇

- 학기 선택 칩 UI와 전용 styled-component(`FieldBlock`/`FieldLabel`/`FieldHint`/`ChipRow`/`Chip`) 삭제
- `sourceYear`/`sourceTerm` 두 state를 `detectedSemester` 하나로 정리 — 이제 학기는 **붙여넣은 표 제목에서 자동 인식**하고, 없으면 가장 최근 학기를 씁니다(기존 기본값과 동일)
- `onApply(rows, source)` 시그니처와 `Subject.sourceYear/sourceTerm` 저장은 그대로 유지 (성적 기록 API 연동에서 쓸 수 있게)

동작 변화는 "칩을 눌러 학기를 바꾸는 경로"가 사라진 것뿐이고, 자동 인식/기본값 경로는 그대로입니다.

## 확인

- `tsc --noEmit` 통과
- `eslint` (해당 파일, `--max-warnings 0`) 통과

관련: #255 (같은 시트의 가이드 UI 개선)

https://claude.ai/code/session_013zHb2uQBLNfwCURUjkzqMc
