### PR TITLE
fix: 뒤로가기 판단을 웹이 맡도록 정리 (모달만 닫히게)

### DIFF
--- a/src/hooks/useCustomNavigate.ts
+++ b/src/hooks/useCustomNavigate.ts
@@ -40,7 +40,9 @@ export function useCustomNavigate() {
     // 1. 숫자가 전달된 경우 (예: -1) 뒤로가기 동작으로 간주
     if (typeof path === "number") {
       if (path === -1 && supportsMultiWebView()) {
-        appBridge.goBack();
+        // 웹이 되돌릴 수 있으면(모달/SPA 히스토리) 웹에서 처리하고, 없을 때만
+        // 네이티브가 이 웹뷰를 pop 한다. appBridgeAdapter 참고.
+        appBridge.requestBack();
       } else {
         reactNavigate(path);
       }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -350,7 +350,9 @@ if (typeof window !== "undefined") {
     // 1. 숫자가 전달된 경우 (뒤로가기)
     if (typeof to === "number") {
       if (to === -1 && supportsMultiWebView()) {
-        appBridge.goBack();
+        // 이 웹뷰 안에 되돌릴 것(모달/SPA 히스토리)이 있으면 웹에서 처리하고,
+        // 없을 때만 네이티브가 웹뷰를 pop 한다. appBridgeAdapter 참고.
+        appBridge.requestBack();
         return Promise.resolve();
       }
       return (originalNavigate as any).call(router, to, opts);

--- a/src/utils/appBridgeAdapter.ts
+++ b/src/utils/appBridgeAdapter.ts
@@ -1,5 +1,6 @@
 import { getAppEnvironmentStatus } from "./getMobilePlatform";
 import { bridgeChannel } from "./bridgeChannel";
+import { handleBackRequest } from "./nativeBackRequest";
 
 /**
  * 단일 브릿지 채널.
@@ -87,7 +88,23 @@ export const appBridge = {
   },
 
   /**
+   * 웹 안의 뒤로가기(헤더 백버튼, `navigate(-1)`) 요청입니다.
+   *
+   * 이 웹뷰 안에 되돌릴 것(오버레이/모달, SPA 히스토리)이 있으면 웹에서 처리하고,
+   * 없을 때만 네이티브에 웹뷰 pop 을 요청합니다. 예전에는 조건 없이 pop 을
+   * 요청해서, 모달을 열어둔 채 백버튼을 누르면 화면 자체가 닫혔습니다
+   * (intip-mobile-app#15). 안드로이드 시스템 백도 네이티브의 `checkBack` 을 거쳐
+   * 같은 판단(`handleBackRequest`)을 탑니다.
+   */
+  requestBack(): void {
+    if (handleBackRequest()) return;
+    this.goBack();
+  },
+
+  /**
    * 현재 웹뷰 액티비티/뷰컨트롤러를 닫고 이전 화면으로 복귀합니다.
+   * 웹 안의 상태와 무관하게 화면을 닫으므로, 사용자의 뒤로가기에는
+   * `requestBack()` 을 쓰세요.
    */
   goBack(): void {
     // 신버전 앱: PlatformChannel 우선

--- a/src/utils/backHandler.ts
+++ b/src/utils/backHandler.ts
@@ -40,7 +40,12 @@ class BackHandlerManager {
     }
   }
 
-  private handleBack(): boolean {
+  /**
+   * 등록된 핸들러로 뒤로가기를 소비했는지 반환한다.
+   * 구앱은 `window.__intipHandleNativeBackRequest` 로, 신앱은 브릿지의
+   * `checkBack` 경로(`nativeBackRequest.ts`)로 같은 로직을 탄다.
+   */
+  handleBack(): boolean {
     // 1. 등록된 오버레이 핸들러가 있으면 가장 최근 등록된 핸들러 실행
     if (this.handlers.length > 0) {
       const handler = this.handlers[this.handlers.length - 1];

--- a/src/utils/bridgeChannel.ts
+++ b/src/utils/bridgeChannel.ts
@@ -1,6 +1,7 @@
 // 공유 브릿지는 packages/intip-bridge git 서브모듈로 두고 소스를 직접 컴파일한다
 // (npm 패키지/레지스트리 없음). CLAUDE.md 참고.
 import { createWebChannel, type WebChannel } from "../../packages/intip-bridge/src/adapters/web";
+import { handleBackRequest } from "./nativeBackRequest";
 
 /**
  * 신 Expo 셸(intip-mobile-app)과의 단일 PlatformChannel.
@@ -28,6 +29,14 @@ if (bridgeChannel) {
     if (!path || window.location.pathname === path) return;
     window.history.pushState({}, "", path);
     window.dispatchEvent(new PopStateEvent("popstate"));
+  });
+
+  // 뒤로가기 위임(안드로이드 시스템 백). 네이티브는 스스로 판단하지 않고 이
+  // 웹뷰에 먼저 물어본다 — 열린 모달/오버레이나 되돌릴 SPA 히스토리는 웹만
+  // 알기 때문. 응답이 늦으면 네이티브가 자체 타임아웃으로 폴백하므로 여기서는
+  // 반드시 동기적으로 답한다.
+  bridgeChannel.on("checkBack", (_value, msg) => {
+    bridgeChannel?.reply(msg, "backResult", { handled: handleBackRequest() });
   });
 
   // "tokenInfoUpdated"(네이티브가 자체 리프레시한 JWT 반영)는 여기서 결선하지 않는다.

--- a/src/utils/nativeBackRequest.ts
+++ b/src/utils/nativeBackRequest.ts
@@ -1,0 +1,32 @@
+import { backHandler } from "./backHandler";
+import { canGoBackInSpa } from "./spaBackDepth";
+
+/**
+ * 뒤로가기 요청의 단일 처리 지점.
+ *
+ * 앱의 뒤로가기(안드로이드 시스템 백 → 네이티브가 보내는 `checkBack`, 그리고 웹
+ * 헤더의 백버튼)는 모두 여기로 모인다. 네이티브는 자기 판단으로 웹뷰를 닫지
+ * 않는다 — 자기 안에 열린 모달이 있는지 아는 쪽은 웹뿐이기 때문이다. 이걸
+ * 건너뛰던 게 intip-mobile-app#15: 서브페이지에서 이미지 뷰어나 필터 오버레이를
+ * 열어둔 채 뒤로가기를 하면 모달이 아니라 화면 자체가 닫혔다.
+ *
+ * 우선순위:
+ *   1. 등록된 오버레이/이탈방지 핸들러 (`backHandler`) — 바텀시트, 미저장 경고 등
+ *   2. 이 웹뷰 안에 쌓인 SPA 히스토리 (`pushState` 기반 모달 포함) → `history.back()`
+ *   3. 둘 다 없으면 처리하지 않음 → 네이티브가 이 웹뷰를 pop
+ */
+export function handleBackRequest(): boolean {
+  // 1. 오버레이 핸들러가 소비하면 히스토리는 건드리지 않는다. 엔트리를 쌓아 둔
+  //    핸들러(useSheetBackHandler)는 닫히면서 자기 엔트리를 스스로 정리한다.
+  if (backHandler.handleBack()) return true;
+
+  // 2. 되돌릴 SPA 엔트리가 있으면 한 칸 되돌린다. pushState 로 모달을 연 화면은
+  //    여기서 popstate 를 받아 모달만 닫는다.
+  if (canGoBackInSpa()) {
+    window.history.back();
+    return true;
+  }
+
+  // 3. 이 웹뷰에서 되돌릴 것이 없다.
+  return false;
+}

--- a/src/utils/spaBackDepth.ts
+++ b/src/utils/spaBackDepth.ts
@@ -1,0 +1,94 @@
+/**
+ * 이 문서(=이 웹뷰)가 로드된 이후 쌓인 SPA 히스토리 깊이 추적.
+ *
+ * 앱에서 뒤로가기를 누르면 "웹이 되돌릴 것을 갖고 있는가"를 웹이 판단해야 한다
+ * (뒤로가기 정책은 `nativeBackRequest.ts` 참고). 그 판단에
+ * `window.history.length` 를 쓰면 안 된다 — 서브페이지 웹뷰가 열릴 때의 초기
+ * length 는 0 이 아니고(같은 WebView 프로세스의 이전 문서까지 포함), 앞으로
+ * 이동한 뒤 되돌아온 경우에도 줄지 않는다.
+ *
+ * 그래서 직접 센다. 진입 시점을 0 으로 두고 `pushState` 마다 +1, 되돌아오면
+ * 그만큼 되돌린다. 카운터만 두고 popstate 에서 -1 하는 방식 대신 **각 엔트리의
+ * state 에 깊이를 새겨** 두고 popstate 에서 착지한 엔트리의 값을 읽는다. 그래야
+ * `history.go(-2)`, 앞으로 가기, 합성 popstate(브릿지의 딥링크 처리) 처럼
+ * -1 이 아닌 이동에서도 어긋나지 않는다.
+ *
+ * 카운트 대상은 이 문서 안의 히스토리 엔트리 전부다:
+ *  - `pushState` 기반 오버레이/모달 (채팅 이미지 뷰어, 강의 필터, 검색바 …)
+ *  - react-router 의 SPA 이동 중 실제 엔트리를 남기는 것(해시/쿼리 이동 등.
+ *    메인 탭이 아닌 경로 이동은 `router.tsx` 가 네이티브 push 로 위임하므로
+ *    애초에 엔트리를 남기지 않는다)
+ * `replaceState` 는 엔트리를 늘리지 않으므로 깊이도 그대로 둔다.
+ */
+
+const DEPTH_KEY = "__intipSpaDepth";
+
+let depth = 0;
+let installed = false;
+
+function readDepth(state: unknown): number {
+  if (state && typeof state === "object" && DEPTH_KEY in state) {
+    const value = (state as Record<string, unknown>)[DEPTH_KEY];
+    if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+      return value;
+    }
+  }
+  // 문서 최초 엔트리(state 없음) = 깊이 0.
+  return 0;
+}
+
+/**
+ * 호출부의 state 를 보존한 채 깊이만 덧붙인다. state 가 객체가 아닌 경우
+ * (원시값)에는 감싸면 호출부 의미가 바뀌므로 건드리지 않는다 — 이 앱에는
+ * 그런 호출부가 없다.
+ */
+function withDepth(state: unknown, value: number): unknown {
+  if (state !== null && state !== undefined && typeof state !== "object") {
+    return state;
+  }
+  return { ...(state as object | null), [DEPTH_KEY]: value };
+}
+
+/**
+ * `history.pushState` / `replaceState` 를 감싸고 popstate 를 구독한다.
+ * 어떤 pushState 보다도 먼저 실행돼야 하므로 이 모듈 로드시 즉시 호출된다.
+ */
+function install(): void {
+  if (installed || typeof window === "undefined") return;
+  installed = true;
+
+  const { history } = window;
+  const originalPushState = history.pushState.bind(history);
+  const originalReplaceState = history.replaceState.bind(history);
+
+  history.pushState = function (state: unknown, unused: string, url?: string | URL | null) {
+    depth += 1;
+    originalPushState(withDepth(state, depth), unused, url);
+  };
+
+  history.replaceState = function (state: unknown, unused: string, url?: string | URL | null) {
+    // 엔트리를 대체할 뿐이므로 깊이는 현재 값 그대로 다시 새긴다.
+    originalReplaceState(withDepth(state, depth), unused, url);
+  };
+
+  // 착지한 엔트리에 새겨진 값이 곧 현재 깊이다(뒤/앞 어느 방향이든).
+  window.addEventListener("popstate", () => {
+    depth = readDepth(window.history.state);
+  });
+
+  // 문서 최초 엔트리에도 0 을 새겨 둬서, 그 엔트리로 되돌아왔을 때
+  // 다른 코드가 남긴 state 를 깊이로 오독하지 않게 한다.
+  originalReplaceState(withDepth(window.history.state, 0), "");
+}
+
+install();
+
+/** 이 웹뷰 안에서 되돌릴 수 있는 SPA 히스토리 엔트리 수. */
+export function getSpaBackDepth(): number {
+  return depth;
+}
+
+/** 이 웹뷰 안에서 뒤로 갈 곳이 남아 있는가. */
+export function canGoBackInSpa(): boolean {
+  return depth > 0;
+}


### PR DESCRIPTION
`inu-appcenter/intip-mobile-app#15` 의 웹 쪽 절반입니다. 네이티브 PR: inu-appcenter/intip-mobile-app#18 · 브릿지 PR: inu-appcenter/intip-bridge#2

## 문제

앱에서 뒤로가기를 하면 네이티브가 스스로 판단해 웹뷰를 통째로 pop 했습니다. 열린 모달이 있는지 아는 쪽은 웹뿐인데 물어보질 않으니, 서브페이지에서 `pushState` 기반 모달(채팅 이미지 뷰어, 강의 필터 오버레이, FloatingSearchBar, 친구목록 선택모드)을 열어둔 채 뒤로가기를 하면 **모달이 아니라 화면 자체가 닫혔습니다.**

메인 탭(root 웹뷰)만 정상이었습니다 — 거기서는 네이티브가 WebView 자체의 `canGoBack` 을 먼저 확인해 `popstate` 가 발화됐기 때문입니다. 즉 서브페이지 한정 비대칭이었습니다.

## 정책

판단을 웹으로 모읍니다. 세 경로 모두 같은 로직(`handleBackRequest`)을 탑니다.

| 이벤트 | 흐름 |
| --- | --- |
| 웹 헤더 백버튼 / `navigate(-1)` | `appBridge.requestBack()` → 웹이 처리, 못 하면 `goBack`(네이티브 pop) |
| Android 시스템 백 (버튼 + 엣지 스와이프) | 네이티브 `checkBack` → 웹이 `backResult { handled }` 로 응답 |
| iOS 스와이프 백 | 네이티브에서 비활성화 (뒤로가기는 헤더 백버튼뿐) |

웹의 판단 순서:
1. 등록된 오버레이/이탈방지 핸들러 (`backHandler`) — 바텀시트, 미저장 경고
2. 이 웹뷰 안에 쌓인 SPA 히스토리 → `history.back()` (모달이 `popstate` 로 닫힘)
3. 둘 다 없으면 `handled: false` → 네이티브가 웹뷰를 pop

## 변경

- **`src/utils/spaBackDepth.ts`** (신규) — 문서 진입 이후 쌓인 SPA 히스토리 깊이 추적. `window.history.length` 는 서브페이지 웹뷰에서 초기값이 0 이 아니라 못 씁니다. 카운터만 두고 popstate 에서 -1 하는 대신 **각 엔트리 state 에 깊이를 새기고** popstate 에서 착지한 엔트리 값을 읽습니다 — `go(-2)`, 앞으로가기, 브릿지 딥링크의 합성 popstate 에서도 어긋나지 않습니다.
- **`src/utils/nativeBackRequest.ts`** (신규) — 뒤로가기 요청의 단일 처리 지점(위 3단계).
- **`src/utils/bridgeChannel.ts`** — `checkBack` 수신 결선. 네이티브가 350ms 로 자르므로 동기 응답합니다.
- **`src/utils/appBridgeAdapter.ts`** — `requestBack()` 추가. 기존 `goBack()` 은 "무조건 웹뷰 닫기" 의미 그대로 남겨 둡니다.
- **`src/utils/backHandler.ts`** — `handleBack` 을 public 으로. 구앱의 `window.__intipHandleNativeBackRequest` 와 신앱의 브릿지 경로가 같은 로직을 탑니다.
- **`src/router.tsx`, `src/hooks/useCustomNavigate.ts`** — `navigate(-1)` 의 신앱 분기를 `requestBack()` 으로.
- 서브모듈 핀 bump (`checkBack`/`backResult` 추가분).

브라우저·구앱 경로는 건드리지 않았습니다(`supportsMultiWebView()` 분기 안에서만 변경).

## 부수 효과 (의도된 것)

미저장 이탈방지(`setPageUnsavedChanges`)가 신앱에서도 동작합니다. 지금까지는 구앱의 `window.__intipHandleNativeBackRequest` 로만 불려서, 신앱에서는 강의 필터 등에서 뒤로가기 시 경고 없이 화면이 닫혔습니다.

## 확인

`tsc --noEmit`, `vite build`, `vitest run`(35 tests) 통과. 이 저장소에는 DOM 테스트 환경(jsdom)이 없어 `spaBackDepth` 단위 테스트는 넣지 않았습니다 — 정책 분기 자체의 단위 테스트는 네이티브 PR 쪽(`backPolicy.test.ts`)에 있습니다.

## QA

- [ ] 채팅방(서브페이지)에서 이미지 열기 → 뒤로가기 → 이미지만 닫히고 채팅방 유지
- [ ] 강의 필터 오버레이 → 뒤로가기 → 오버레이만 닫힘
- [ ] FloatingSearchBar / 친구목록 선택모드 → 뒤로가기 → 오버레이만 닫힘
- [ ] `/chat/list`(메인탭) 검색 오버레이 회귀 없음
- [ ] 내부 히스토리가 없는 단순 조회 서브페이지 → 뒤로가기 한 번에 화면 닫힘
- [ ] 헤더 백버튼도 위와 동일하게 동작
- [ ] 일반 브라우저에서 뒤로가기 정상

## 머지 순서

브릿지 PR(inu-appcenter/intip-bridge#2)을 먼저 머지한 뒤, 이 브랜치의 서브모듈 핀을 브릿지 main SHA 로 다시 bump 해야 합니다. 네이티브 PR 과는 함께 배포돼야 합니다(웹만 먼저 나가도 `checkBack` 이 안 오므로 무해하고, 네이티브만 먼저 나가면 타임아웃 폴백으로 기존 동작).

https://claude.ai/code/session_01WKykTYotqrktBosPwgNfLi
