### PR TITLE
feat: 딥링크 도메인 연결 파일(AASA/assetlinks) + iOS 앱 설치 유도 배너

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,29 @@
       content="인천대학교 학생들을 위한 팁을 담다"
     />
     <meta property="og:url" content="https://intip.inuappcenter.kr/" />
+    <!-- iOS Safari 네이티브 Smart App Banner. 앱이 없으면 설치를, 있으면 '열기'를
+         띄운다. `app-argument`에 지금 보고 있는 URL을 넣어야 '열기'로 진입했을 때
+         앱이 같은 화면으로 갈 수 있다(앱 쪽 `+native-intent`가 이 URL을 받는다).
+         Safari가 head를 파싱할 때 값이 있어야 하므로 인라인 스크립트로 바로 채운다.
+         Safari가 아닌 iOS 브라우저·인앱 웹뷰는 이 메타를 무시하므로, 그쪽은
+         커스텀 배너(`components/common/AppInstallBanner.tsx`)가 담당한다. -->
+    <meta name="apple-itunes-app" content="app-id=6740070975" />
+    <script>
+      (function () {
+        try {
+          var meta = document.querySelector('meta[name="apple-itunes-app"]');
+          if (meta) {
+            meta.setAttribute(
+              "content",
+              "app-id=6740070975, app-argument=" + window.location.href,
+            );
+          }
+        } catch (error) {
+          /* 메타 갱신 실패해도 배너 자체는 뜬다(앱은 기본 화면으로 열림) */
+        }
+      })();
+    </script>
+
 <!--    네이버 검색 등록을 위한 태그-->
     <meta name="naver-site-verification" content="d21e463ea38d2db93ba9d1a7ae7cbba5da7dc29f" />
 

--- a/public/_headers
+++ b/public/_headers
@@ -8,14 +8,16 @@
 # AASA는 확장자가 없어 Pages가 타입을 못 정하고 text/html로 나가는데, Apple은
 # application/json이 아니면 도메인 연결을 인정하지 않는다. 요청 경로 기준으로
 # 매칭되므로 rewrite 이전 경로와 실제 파일 경로 둘 다 적어 준다.
+#
+# Cache-Control은 일부러 적지 않는다. Pages는 여러 규칙이 걸리면 같은 헤더를
+# 덮어쓰지 않고 값을 이어 붙이므로(프리뷰 배포에서 확인:
+# `no-cache, no-store, must-revalidate, public, max-age=3600`), 위 `/*` 규칙과
+# 모순되는 한 줄이 나갈 뿐이다. 증명 파일은 항상 최신이면 되니 `/*`의 no-store로 둔다.
 /.well-known/apple-app-site-association
   Content-Type: application/json
-  Cache-Control: public, max-age=3600
 
 /.well-known/assetlinks.json
   Content-Type: application/json
-  Cache-Control: public, max-age=3600
 
 /app-links/*
   Content-Type: application/json
-  Cache-Control: public, max-age=3600

--- a/public/_headers
+++ b/public/_headers
@@ -3,3 +3,19 @@
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
+
+# 딥링크 도메인 소유 증명 파일(`public/app-links/`, `_redirects`로 `/.well-known/`에 매핑).
+# AASA는 확장자가 없어 Pages가 타입을 못 정하고 text/html로 나가는데, Apple은
+# application/json이 아니면 도메인 연결을 인정하지 않는다. 요청 경로 기준으로
+# 매칭되므로 rewrite 이전 경로와 실제 파일 경로 둘 다 적어 준다.
+/.well-known/apple-app-site-association
+  Content-Type: application/json
+  Cache-Control: public, max-age=3600
+
+/.well-known/assetlinks.json
+  Content-Type: application/json
+  Cache-Control: public, max-age=3600
+
+/app-links/*
+  Content-Type: application/json
+  Cache-Control: public, max-age=3600

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,15 @@
+# 딥링크(iOS Universal Links / Android App Links) 도메인 소유 증명 파일.
+#
+# Apple과 Google은 이 두 파일을 반드시 `/.well-known/` 아래에서 200으로 받아야
+# 도메인↔앱 연결을 인정한다. 그런데 Cloudflare Pages는 `.`으로 시작하는 디렉터리를
+# 업로드하지 않는 사례가 반복 보고돼 있어(wrangler#980 등), `public/.well-known/`에
+# 파일을 두면 배포본에서 통째로 사라질 수 있다.
+#
+# 그래서 실제 파일은 점 없는 `/app-links/`에 두고, 규격이 요구하는 경로로는 여기서
+# 200 rewrite(리다이렉트 아님 — Apple은 3xx를 거부한다)로 매핑한다. 원본이 한 벌뿐이라
+# 두 경로가 서로 어긋날 일이 없다.
+#
+# Content-Type(application/json)은 `_headers`에서 지정한다. AASA는 확장자가 없어
+# Pages가 타입을 정하지 못하기 때문.
+/.well-known/apple-app-site-association  /app-links/apple-app-site-association  200
+/.well-known/assetlinks.json             /app-links/assetlinks.json             200

--- a/public/app-links/apple-app-site-association
+++ b/public/app-links/apple-app-site-association
@@ -1,0 +1,30 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["AANGG4Q668.kr.inuappcenter.intip"],
+        "components": [
+          {
+            "/": "/.well-known/*",
+            "exclude": true,
+            "comment": "Domain-verification files themselves always stay on the web."
+          },
+          {
+            "/": "/privacy-policy.html",
+            "exclude": true,
+            "comment": "Static legal page linked from the store listings: must open in a browser, including for reviewers who do not have the app installed."
+          },
+          {
+            "/": "/terms-of-use.html",
+            "exclude": true,
+            "comment": "Same as the privacy policy: store-review and external-linking surface."
+          },
+          {
+            "/": "*",
+            "comment": "Every other portal path opens in the app when it is installed."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/public/app-links/assetlinks.json
+++ b/public/app-links/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "inu.appcenter.intip_android",
+      "sha256_cert_fingerprints": [
+        "REPLACE_WITH_PLAY_APP_SIGNING_SHA256"
+      ]
+    }
+  }
+]

--- a/src/components/common/AppInstallBanner.tsx
+++ b/src/components/common/AppInstallBanner.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useLocation } from "react-router-dom";
+import styled from "styled-components";
+import { X } from "lucide-react";
+
+import {
+  APP_STORE_URL,
+  INSTALL_BANNER_HEIGHT,
+  readBannerDismissed,
+  shouldShowInstallBanner,
+  writeBannerDismissed,
+} from "@/utils/appInstallBanner";
+import { getAppEnvironmentStatus } from "@/utils/getMobilePlatform";
+import { mixpanelTrack } from "@/utils/mixpanel";
+
+const PROMO_NAME = "App Install Banner";
+const PROMO_LOCATION = "Deep Link Top Banner";
+
+/**
+ * 앱 미설치 iOS 사용자용 상단 설치 유도 배너.
+ *
+ * 딥링크(Universal Links)를 눌렀는데 앱이 없으면 그대로 모바일 웹이 열린다. 이때
+ * Safari는 `index.html`의 `apple-itunes-app` 메타로 네이티브 Smart App Banner가
+ * 뜨지만, 카카오톡·인스타 인앱 브라우저나 iOS 크롬에서는 아무것도 뜨지 않는다.
+ * 이 컴포넌트가 그 구멍을 메운다(노출 조건은 `utils/appInstallBanner.ts`).
+ *
+ * 레이아웃: 배너가 떠 있는 동안 `--native-safe-area-inset-top`에 배너 높이를 더한다.
+ * 모바일 헤더가 이미 그 변수 기준으로 자리를 잡으므로(`MobileHeader`), 배너를 위해
+ * 각 화면을 따로 손볼 필요가 없다.
+ */
+export default function AppInstallBanner() {
+  const location = useLocation();
+  const [dismissed, setDismissed] = useState(readBannerDismissed);
+
+  const visible = shouldShowInstallBanner({
+    userAgent: typeof navigator === "undefined" ? "" : navigator.userAgent,
+    appStatus: getAppEnvironmentStatus(),
+    pathname: location.pathname,
+    dismissed,
+  });
+
+  useEffect(() => {
+    if (!visible) return;
+
+    const root = document.documentElement;
+    root.style.setProperty(
+      "--native-safe-area-inset-top",
+      `calc(env(safe-area-inset-top, 0px) + ${INSTALL_BANNER_HEIGHT}px)`,
+    );
+    // 인라인 값을 지우면 CommonStyles의 `:root` 정의로 되돌아간다.
+    return () => {
+      root.style.removeProperty("--native-safe-area-inset-top");
+    };
+  }, [visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+    mixpanelTrack.promotionImpression(PROMO_NAME, PROMO_LOCATION);
+  }, [visible]);
+
+  if (!visible) return null;
+
+  const handleOpen = () => {
+    mixpanelTrack.promotionClicked(PROMO_NAME, "Open Button", PROMO_LOCATION);
+    // `window.open`은 카카오톡 등 인앱 브라우저에서 팝업으로 막히는 경우가 있다.
+    // 같은 창에서 이동하면 iOS가 App Store 앱을 띄우고, 사용자가 돌아오면 보던
+    // 페이지가 그대로 남아 있다.
+    window.location.href = APP_STORE_URL;
+  };
+
+  const handleDismiss = () => {
+    mixpanelTrack.promotionClicked(
+      PROMO_NAME,
+      "Dismiss Button",
+      PROMO_LOCATION,
+    );
+    writeBannerDismissed();
+    setDismissed(true);
+  };
+
+  return createPortal(
+    <Banner>
+      <DismissButton type="button" onClick={handleDismiss} aria-label="배너 닫기">
+        <X size={18} />
+      </DismissButton>
+      <AppIcon src="/icon.svg" alt="" aria-hidden />
+      <TextGroup>
+        <Title>INTIP 앱으로 보기</Title>
+        <Subtitle>앱에서 더 빠르게, 알림까지 받아보세요</Subtitle>
+      </TextGroup>
+      <OpenButton type="button" onClick={handleOpen}>
+        열기
+      </OpenButton>
+    </Banner>,
+    document.body,
+  );
+}
+
+const Banner = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 99999;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: calc(env(safe-area-inset-top, 0px) + ${INSTALL_BANNER_HEIGHT}px);
+  padding: env(safe-area-inset-top, 0px) 12px 0;
+  box-sizing: border-box;
+  background: #ffffff;
+  border-bottom: 1px solid #e5e9f0;
+`;
+
+const DismissButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  color: #8b95a1;
+`;
+
+const AppIcon = styled.img`
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  flex-shrink: 0;
+`;
+
+const TextGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+`;
+
+const Title = styled.span`
+  font-size: 14px;
+  font-weight: 600;
+  color: #17325c;
+  line-height: 1.3;
+`;
+
+const Subtitle = styled.span`
+  font-size: 12px;
+  color: #6b7684;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const OpenButton = styled.button`
+  flex-shrink: 0;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: #2563eb;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+`;

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -21,6 +21,7 @@ import { DESKTOP_MEDIA } from "@/styles/responsive";
 import AIChatFloatingButton from "@/components/common/AIChatFloatingButton";
 import { getAppEnvironmentStatus } from "@/utils/getMobilePlatform";
 import AppUpdateModal from "@/components/common/AppUpdateModal";
+import AppInstallBanner from "@/components/common/AppInstallBanner";
 import { safeLocalStorage } from "@/utils/safeStorage";
 
 
@@ -168,6 +169,9 @@ export default function RootLayout() {
   return (
     <HeaderProvider>
       <ScrollBarStyles />
+      {/* 앱 미설치 iOS 사용자용 설치 유도 배너. 노출 조건은 컴포넌트 안에서
+          판단하고, 해당 없으면 아무것도 렌더하지 않는다. */}
+      <AppInstallBanner />
       <ScreenContainer>
         {outlet}
         {(location.pathname === ROUTES.HOME ||

--- a/src/utils/__tests__/appInstallBanner.test.ts
+++ b/src/utils/__tests__/appInstallBanner.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isIOSSafari,
+  isIOSUserAgent,
+  shouldShowInstallBanner,
+} from "../appInstallBanner";
+
+const UA = {
+  iosSafari:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+  iosChrome:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1",
+  iosKakao:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 KAKAOTALK 10.5.0",
+  iosInstagram:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 331.0.0.37.90 (iPhone14,2; iOS 17_5; ko_KR)",
+  androidChrome:
+    "Mozilla/5.0 (Linux; Android 14; SM-S911N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36",
+  macSafari:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
+} as const;
+
+const base = {
+  appStatus: "BROWSER",
+  pathname: "/friend/invite/ABC123",
+  dismissed: false,
+} as const;
+
+describe("isIOSUserAgent", () => {
+  it("아이폰 계열만 iOS로 본다", () => {
+    expect(isIOSUserAgent(UA.iosSafari)).toBe(true);
+    expect(isIOSUserAgent(UA.iosKakao)).toBe(true);
+    expect(isIOSUserAgent(UA.androidChrome)).toBe(false);
+    expect(isIOSUserAgent(UA.macSafari)).toBe(false);
+  });
+});
+
+describe("isIOSSafari", () => {
+  it("iOS Safari만 참", () => {
+    expect(isIOSSafari(UA.iosSafari)).toBe(true);
+  });
+
+  it("Safari/ 토큰을 달고 오는 iOS 크롬은 거짓", () => {
+    expect(isIOSSafari(UA.iosChrome)).toBe(false);
+  });
+
+  it("Version/ 이 없는 인앱 웹뷰는 거짓", () => {
+    expect(isIOSSafari(UA.iosKakao)).toBe(false);
+    expect(isIOSSafari(UA.iosInstagram)).toBe(false);
+  });
+
+  it("데스크톱 Safari는 iOS가 아니므로 거짓", () => {
+    expect(isIOSSafari(UA.macSafari)).toBe(false);
+  });
+});
+
+describe("shouldShowInstallBanner", () => {
+  it("iOS 인앱/대체 브라우저에서 뜬다", () => {
+    expect(
+      shouldShowInstallBanner({ ...base, userAgent: UA.iosKakao }),
+    ).toBe(true);
+    expect(
+      shouldShowInstallBanner({ ...base, userAgent: UA.iosInstagram }),
+    ).toBe(true);
+    expect(
+      shouldShowInstallBanner({ ...base, userAgent: UA.iosChrome }),
+    ).toBe(true);
+  });
+
+  it("iOS Safari는 네이티브 Smart App Banner가 담당하므로 뜨지 않는다", () => {
+    expect(
+      shouldShowInstallBanner({ ...base, userAgent: UA.iosSafari }),
+    ).toBe(false);
+  });
+
+  it("공식 앱 웹뷰 안에서는 뜨지 않는다", () => {
+    expect(
+      shouldShowInstallBanner({
+        ...base,
+        userAgent: UA.iosKakao,
+        appStatus: "NEW_APP",
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowInstallBanner({
+        ...base,
+        userAgent: UA.iosKakao,
+        appStatus: "OLD_APP",
+      }),
+    ).toBe(false);
+  });
+
+  it("Android·데스크톱은 이번 범위가 아니다", () => {
+    expect(
+      shouldShowInstallBanner({ ...base, userAgent: UA.androidChrome }),
+    ).toBe(false);
+    expect(
+      shouldShowInstallBanner({ ...base, userAgent: UA.macSafari }),
+    ).toBe(false);
+  });
+
+  it("이번 세션에서 닫았으면 다시 뜨지 않는다", () => {
+    expect(
+      shouldShowInstallBanner({
+        ...base,
+        userAgent: UA.iosKakao,
+        dismissed: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("홈은 기존 설치 유도 바텀시트가 담당하므로 제외한다", () => {
+    for (const pathname of ["/", "/m", "/home", "/m/home", "/home/v2"]) {
+      expect(
+        shouldShowInstallBanner({ ...base, userAgent: UA.iosKakao, pathname }),
+      ).toBe(false);
+    }
+  });
+});

--- a/src/utils/appInstallBanner.ts
+++ b/src/utils/appInstallBanner.ts
@@ -1,0 +1,128 @@
+/**
+ * 딥링크(Universal Links)로 들어왔지만 앱이 없는 iOS 사용자에게 설치를 유도하는
+ * 상단 배너의 노출 정책.
+ *
+ * iOS Safari는 `index.html`의 `apple-itunes-app` 메타(네이티브 Smart App Banner)가
+ * 담당하고, 이 모듈이 다루는 커스텀 배너는 **Smart App Banner가 렌더되지 않는**
+ * iOS 환경(크롬·카카오톡·인스타그램 등 인앱 브라우저)만 메꾼다. 둘이 동시에 뜨면
+ * 화면 위쪽이 두 겹이 되므로 Safari에서는 커스텀 배너를 내린다.
+ *
+ * DOM·React에 의존하지 않는 순수 함수로 두어 UA 문자열만으로 단위 테스트한다.
+ */
+import type { AppEnvironmentStatus } from "./getMobilePlatform";
+
+/** App Store 앱 ID. Smart App Banner 메타(`index.html`)와 같은 값이어야 한다. */
+export const APP_STORE_APP_ID = "6740070975";
+
+/** 배너의 '열기' 버튼이 여는 스토어 페이지. */
+export const APP_STORE_URL = `https://apps.apple.com/kr/app/id${APP_STORE_APP_ID}`;
+
+/** 배너 높이(px). 헤더/콘텐츠를 밀어내는 계산에도 그대로 쓰인다. */
+export const INSTALL_BANNER_HEIGHT = 60;
+
+/** 세션 단위 닫힘 플래그 키. */
+export const INSTALL_BANNER_DISMISS_KEY = "intip.installBanner.dismissed";
+
+/**
+ * 홈은 기존 설치 유도 바텀시트(`InstallPromotionBottomSheet`)가 이미 담당한다.
+ * 같은 화면에서 위·아래로 설치 유도가 두 개 뜨는 걸 막기 위해 제외한다.
+ */
+const HOME_PATHS = ["/", "/m", "/home", "/m/home", "/home/v2"];
+
+/**
+ * iOS에서 Safari가 아님을 알려 주는 UA 마커.
+ *
+ * 대체 브라우저(CriOS=Chrome, FxiOS=Firefox …)와 인앱 웹뷰(카카오톡·인스타 …)를
+ * 한 목록으로 묶는다. 커스텀 배너 입장에서 둘의 처리가 같기 때문 — Smart App
+ * Banner를 렌더하는 건 Safari뿐이라, Safari가 아니면 전부 커스텀 배너 대상이다.
+ */
+const NON_SAFARI_MARKERS = [
+  // 대체 브라우저
+  "CRIOS",
+  "FXIOS",
+  "EDGIOS",
+  "OPT/",
+  "DUCKDUCKGO",
+  "WHALE",
+  // 인앱 브라우저
+  "KAKAOTALK",
+  "INSTAGRAM",
+  "FBAN",
+  "FBAV",
+  "LINE/",
+  "NAVER",
+  "DAUMAPPS",
+  "EVERYTIMEAPP",
+  "SNAPCHAT",
+  "TIKTOK",
+  "TWITTER",
+];
+
+/** iOS(아이폰/아이팟/아이패드) 기기인지. */
+export function isIOSUserAgent(userAgent: string): boolean {
+  return /iPhone|iPad|iPod/i.test(userAgent);
+}
+
+/**
+ * iOS **Safari**인지. Smart App Banner를 렌더하는 유일한 브라우저다.
+ *
+ * Safari는 `Version/17.0 Mobile/15E148 Safari/604.1`처럼 `Version/`과 `Safari/`를
+ * 함께 갖는다. 인앱 웹뷰(WKWebView)는 같은 WebKit이지만 `Version/`이 없고, 대체
+ * 브라우저는 자기 마커를 붙이므로 이 둘을 조합하면 갈라진다.
+ */
+export function isIOSSafari(userAgent: string): boolean {
+  if (!isIOSUserAgent(userAgent)) return false;
+  const ua = userAgent.toUpperCase();
+  if (NON_SAFARI_MARKERS.some((marker) => ua.includes(marker))) return false;
+  return ua.includes("SAFARI/") && ua.includes("VERSION/");
+}
+
+interface InstallBannerContext {
+  userAgent: string;
+  /** `getAppEnvironmentStatus()` 결과. 공식 앱 웹뷰면 배너를 띄우지 않는다. */
+  appStatus: AppEnvironmentStatus;
+  /** 현재 라우트(`location.pathname`). */
+  pathname: string;
+  /** 이번 세션에서 사용자가 이미 닫았는지. */
+  dismissed: boolean;
+}
+
+/** 커스텀 상단 설치 배너를 지금 띄워야 하는지. */
+export function shouldShowInstallBanner({
+  userAgent,
+  appStatus,
+  pathname,
+  dismissed,
+}: InstallBannerContext): boolean {
+  // 공식 앱 안(신·구버전 모두)에서는 설치를 유도할 이유가 없다.
+  if (appStatus !== "BROWSER") return false;
+  // 이번 범위는 iOS만. Android는 App Links가 미설치 시 그냥 웹으로 떨어진다.
+  if (!isIOSUserAgent(userAgent)) return false;
+  // Safari는 네이티브 Smart App Banner가 대신 뜬다.
+  if (isIOSSafari(userAgent)) return false;
+  if (dismissed) return false;
+  if (HOME_PATHS.includes(pathname)) return false;
+  return true;
+}
+
+/**
+ * 세션 닫힘 플래그 읽기/쓰기. 카카오톡 등 일부 인앱 브라우저는 스토리지 접근에
+ * SecurityError를 던지므로(`safeStorage.ts`와 같은 이유) 항상 감싸서 접근한다.
+ */
+export function readBannerDismissed(): boolean {
+  try {
+    if (typeof window === "undefined" || !window.sessionStorage) return false;
+    return sessionStorage.getItem(INSTALL_BANNER_DISMISS_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeBannerDismissed(): void {
+  try {
+    if (typeof window === "undefined" || !window.sessionStorage) return;
+    sessionStorage.setItem(INSTALL_BANNER_DISMISS_KEY, "1");
+  } catch {
+    /* 스토리지가 막힌 환경에서는 이번 화면에서만 닫힘(상태는 메모리로 유지) */
+  }
+}


### PR DESCRIPTION
Closes #302
앱 레포 대응 PR: inu-appcenter/intip-mobile-app#20

## 무엇을

포털 URL을 눌렀을 때 앱이 있으면 앱으로, 없으면 웹 + 설치 유도로 보내기 위해
이 레포가 맡는 두 가지를 넣었다.

### 1. 도메인 소유 증명 파일

딥링크는 도메인이 앱을 인증해 주는 구조라, 앱만 설정해서는 동작하지 않는다.

- `public/app-links/apple-app-site-association` — `AANGG4Q668.kr.inuappcenter.intip`
- `public/app-links/assetlinks.json` — `inu.appcenter.intip_android`
- `public/_redirects` — 위 파일을 규격 경로 `/.well-known/...`로 **200 rewrite**
- `public/_headers` — 두 경로에 `Content-Type: application/json`

**점 없는 경로에 두고 rewrite한 이유**: Cloudflare Pages가 `.`으로 시작하는
디렉터리를 업로드하지 않는 사례가 반복 보고돼 있다
([community](https://community.cloudflare.com/t/allow-to-serve-from-well-known/507153),
[wrangler#980](https://github.com/cloudflare/wrangler-legacy/issues/980)).
`public/.well-known/`에 두면 배포본에서 통째로 빠질 수 있어서, 업로드가 보장되는
경로에 원본을 두고 규격 경로로 매핑했다. 200 rewrite는 Apple이 거부하는 3xx
리다이렉트가 아니고, 원본이 한 벌뿐이라 두 경로가 어긋날 일도 없다.

`Content-Type`을 못 박은 이유는 AASA에 확장자가 없어 Pages가 타입을 정하지 못하고
SPA 폴백에 걸려 `text/html`로 나가기 때문(이슈 본문의 `curl` 결과). Apple은
`application/json`이 아니면 도메인 연결을 인정하지 않는다.

AASA `exclude`: `/privacy-policy.html`, `/terms-of-use.html`, `/.well-known/*`.
스토어 심사·외부 링크용 정적 페이지라 앱으로 가로채면 안 된다. 앱 레포의 제외
경로 목록과 값을 맞춰 두었다.

### 2. iOS 설치 유도 배너

| 환경 | 수단 |
|---|---|
| iOS Safari | 네이티브 Smart App Banner (`apple-itunes-app` 메타) |
| iOS 크롬 / 카카오톡·인스타 인앱 브라우저 | 커스텀 상단 배너 |
| 공식 앱 웹뷰 / Android / 데스크톱 | 노출 안 함 |

- Smart App Banner는 인라인 스크립트로 `app-argument`에 현재 URL을 채운다.
  '열기'로 진입한 앱이 같은 화면을 띄우게 하기 위한 값이고, 앱 쪽
  `+native-intent`가 이 URL을 받아 처리한다.
- 커스텀 배너는 Smart App Banner가 **렌더되지 않는** iOS 환경만 메꾼다. 둘이 같이
  뜨면 화면 위쪽이 두 겹이 되기 때문. Safari 판별은 `Version/` + `Safari/` 조합에
  대체 브라우저·인앱 웹뷰 마커를 빼는 방식 — 인앱 웹뷰(WKWebView)는 `Safari/`는
  달고 오지만 `Version/`이 없다는 점을 쓴다.
- 홈은 기존 `InstallPromotionBottomSheet`가 담당하므로 제외했다(같은 화면에 설치
  유도 두 개 방지). 닫으면 세션 단위로 기억한다.
- 레이아웃은 배너가 떠 있는 동안 `--native-safe-area-inset-top`에 배너 높이를
  더해서 처리했다. 모바일 헤더가 이미 그 변수 기준으로 자리를 잡아, 화면을 하나씩
  손대지 않아도 헤더·콘텐츠가 함께 밀린다.

## 검증

- `npm run build` (tsc + vite) 통과, `dist/`에 `app-links/`·`_redirects`·`_headers` 포함 확인
- `npx vitest run src/utils/__tests__/appInstallBanner.test.ts` — 11개 통과
  (Safari / iOS 크롬 / 카카오톡 / 인스타 / Android / 데스크톱 / 앱 웹뷰 / 세션 닫힘 / 홈 제외)
- ESLint: `dev` 브랜치 자체가 이미 깨져 있다(ESLint 9인데 설정이 `.eslintrc.cjs`).
  `ESLINT_USE_FLAT_CONFIG=false`로 돌리면 이번에 추가/수정한 파일은 전부 클린이고,
  유일한 에러는 기존 `RootLayout.tsx:84`의 FCM 코드(이 PR과 무관).

## 머지 전 확인 (배포 의존)

- [x] **프리뷰 배포에서** `curl -sI https://<preview>/.well-known/apple-app-site-association`
      → `200` + `content-type: application/json`
- [x] 같은 확인을 `/.well-known/assetlinks.json`으로도
- [x] `_redirects` 추가가 SPA 라우팅을 건드리지 않는지(딥 링크 새로고침으로 아무 경로나)
- [ ] Play Console → 설정 → 앱 서명 → **앱 서명 키 인증서**의 SHA-256 지문으로
      `assetlinks.json`의 `REPLACE_WITH_PLAY_APP_SIGNING_SHA256` 교체
      (업로드 키 지문도 같이 넣으면 사내 배포본까지 커버)
- [ ] iOS 실기기에서 Safari 배너 노출, 카카오톡 인앱에서 커스텀 배너 노출

## 배포 후 확인

- [ ] `https://app-site-association.cdn-apple.com/a/v1/intip.inuappcenter.kr`
- [ ] `https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://intip.inuappcenter.kr&relation=delegate_permission/common.handle_all_urls`

https://claude.ai/code/session_011HVFNuANxPsh6BFfKsRsfW