### PR TITLE
fix: 시간표 마법사 강의 목록 탭 시 과목 상세 시트 표시 (#249)

### DIFF
--- a/src/components/mobile/timetable/ClassDetailBottomSheet.tsx
+++ b/src/components/mobile/timetable/ClassDetailBottomSheet.tsx
@@ -25,6 +25,10 @@ interface ClassDetailBottomSheetProps {
   colorMap: Map<string, string>;
   onEdit?: (id: number) => void;
   onDelete?: (id: number) => void;
+  // 실제 내 시간표 요소가 아닌 읽기 전용 미리보기(예: 마법사 후보 강의)에서 사용.
+  // 메모 표시/편집을 막아, 미리보기 항목의 memo 저장 시도가 activeTimetable의
+  // 이름이 같은 실제 요소를 잘못 덮어쓰는 것을 방지한다.
+  readOnly?: boolean;
 }
 
 const formatHour = (hour: number) => {
@@ -41,6 +45,7 @@ export default function ClassDetailBottomSheet({
   colorMap,
   onEdit,
   onDelete,
+  readOnly = false,
 }: ClassDetailBottomSheetProps) {
   useSheetBackHandler(open, () => onOpenChange(false));
   const navigate = useNavigate();
@@ -206,7 +211,7 @@ export default function ClassDetailBottomSheet({
 
   // 메모는 본인만 보는 개인 메모. 친구 소유 항목은 조회/편집 모두 불가하다.
   const hasMemo = Boolean(liveClass.memo && liveClass.memo.trim());
-  const canEditMemo = !liveClass.isFriendOwned;
+  const canEditMemo = !liveClass.isFriendOwned && !readOnly;
 
   const handleSaveMemo = () => {
     if (activeTimetableId === null) return;

--- a/src/components/mobile/timetable/wizard/WizardDetailScreen.tsx
+++ b/src/components/mobile/timetable/wizard/WizardDetailScreen.tsx
@@ -1,7 +1,10 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import styled from "styled-components";
 import { ChevronRight } from "lucide-react";
-import TimetableGrid from "@/components/mobile/timetable/TimetableGrid";
+import TimetableGrid, {
+  type ClassItem,
+} from "@/components/mobile/timetable/TimetableGrid";
+import ClassDetailBottomSheet from "@/components/mobile/timetable/ClassDetailBottomSheet";
 import { formatCourseMeetings, mapWizardCoursesToClassItems } from "@/utils/timetableWizardFormat";
 import { getOnlineTypeLabel } from "@/components/mobile/timetable/filter/courseFilterModel";
 import type { WizardCandidate } from "@/types/timetableWizard";
@@ -15,6 +18,43 @@ const WizardDetailScreen = ({ candidate }: WizardDetailScreenProps) => {
     () => mapWizardCoursesToClassItems(candidate.courses),
     [candidate.courses],
   );
+
+  // 강의 목록 행의 accent bar와 동일한 색으로 상세 시트의 점 색상을 맞춘다.
+  const colorMap = useMemo(() => {
+    const map = new Map<string, string>();
+    candidate.courses.forEach((course, index) => {
+      map.set(course.title, BLOCK_COLORS[index % BLOCK_COLORS.length]);
+    });
+    return map;
+  }, [candidate.courses]);
+
+  const [selectedClass, setSelectedClass] = useState<ClassItem | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+
+  // meetings가 없는(비대면/온라인 전용) 강의도 상세를 열 수 있도록 gridEvents 조회에
+  // 의존하지 않고 candidate.courses에서 직접 ClassItem을 구성한다.
+  const handleCourseRowClick = (
+    course: WizardCandidate["courses"][number],
+    courseIndex: number,
+  ) => {
+    const firstMeeting = course.meetings[0];
+    setSelectedClass({
+      id: courseIndex * 1000,
+      name: course.title,
+      room: firstMeeting?.location ?? "",
+      day: firstMeeting?.day ?? 0,
+      startTime: firstMeeting?.startTime ?? 0,
+      endTime: firstMeeting?.endTime ?? 0,
+      credits: course.credit,
+      professor: course.professor ?? undefined,
+      ssupTypeName: course.ssupTypeName ?? undefined,
+      ssupTypeCode: course.ssupTypeCode ?? undefined,
+      courseOfferingId: course.courseOfferingId,
+      courseId: course.subjectNumber,
+      isUntimed: course.meetings.length === 0,
+    });
+    setDetailOpen(true);
+  };
 
   return (
     <ScrollContent>
@@ -46,7 +86,10 @@ const WizardDetailScreen = ({ candidate }: WizardDetailScreenProps) => {
               course.ssupTypeCode,
             );
             return (
-              <CourseRow key={course.subjectNumber}>
+              <CourseRow
+                key={course.subjectNumber}
+                onClick={() => handleCourseRowClick(course, index)}
+              >
                 <AccentBar $colorIndex={index} />
                 <CourseTextWrap>
                   <CourseName>{course.title}</CourseName>
@@ -63,6 +106,15 @@ const WizardDetailScreen = ({ candidate }: WizardDetailScreenProps) => {
       </Card>
 
       <BottomActionsSpacer />
+
+      <ClassDetailBottomSheet
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        selectedClass={selectedClass}
+        allEvents={gridEvents}
+        colorMap={colorMap}
+        readOnly
+      />
     </ScrollContent>
   );
 };
@@ -162,6 +214,7 @@ const CourseRow = styled.div`
   gap: 12px;
   padding: 12px 0;
   border-bottom: 1px solid var(--border-default, #e5e8eb);
+  cursor: pointer;
 
   &:last-child {
     border-bottom: none;

--- a/src/utils/timetableWizardFormat.ts
+++ b/src/utils/timetableWizardFormat.ts
@@ -21,6 +21,8 @@ export const formatCourseMeta = (course: WizardCourseOption): string => {
 };
 
 // 마법사 후보 강의를 TimetableGrid가 그릴 수 있는 ClassItem으로 변환 (읽기 전용 미리보기용)
+// courseOfferingId/courseId(학수번호)도 함께 채워서, ClassDetailBottomSheet가 개설강의/강의
+// 상세를 조회해 교수명·학점·이수구분·평가방식 등을 보강할 수 있게 한다(#249).
 export const mapWizardCoursesToClassItems = (
   courses: WizardCourseOption[],
 ): ClassItem[] =>
@@ -36,5 +38,7 @@ export const mapWizardCoursesToClassItems = (
       professor: course.professor ?? undefined,
       ssupTypeName: course.ssupTypeName ?? undefined,
       ssupTypeCode: course.ssupTypeCode ?? undefined,
+      courseOfferingId: course.courseOfferingId,
+      courseId: course.subjectNumber,
     })),
   );


### PR DESCRIPTION
## 요약
시간표 마법사 상세 화면(`WizardDetailScreen`)의 강의 목록 행에 `ChevronRight` 아이콘만 있고 `onClick`이 없어 탭해도 아무 반응이 없던 문제를 고칩니다.

## 변경 사항
- 강의 목록 행을 탭하면 기존 시간표 편집 화면에서 쓰던 `ClassDetailBottomSheet`가 열립니다.
- `mapWizardCoursesToClassItems`에 `courseOfferingId`/`courseId`를 채워 시트가 개설강의·강의 상세를 조회해 교수명·학점·이수구분·평가방식 등을 보강하도록 했습니다.
- meetings가 없는(비대면/온라인) 강의도 상세를 열 수 있도록 `candidate.courses`에서 직접 항목을 구성합니다.
- `ClassDetailBottomSheet`에 `readOnly` prop을 추가해, 마법사 후보(실제 시간표 요소가 아님)에서 메모 표시/편집을 막습니다 — 그렇지 않으면 저장 시 activeTimetable의 동명 요소를 잘못 덮어쓸 수 있습니다.

## 확인
- `tsc --noEmit`, `npm run build` 통과
- 변경 파일 대상 eslint(레거시 설정으로 실행) 통과 — 리포의 `eslint.config.js`가 없어 `npm run lint`는 이 브랜치와 무관하게 현재 dev에서도 실행되지 않는 상태입니다(별도 확인 필요, 이 PR 범위 밖).

Closes #249

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>