### PR TITLE
fix: 정원/수강인원 배지에 라벨 추가, 하나만 있어도 표시 (#256)

### DIFF
--- a/src/components/mobile/timetable/MobileCourseSearchSheet.tsx
+++ b/src/components/mobile/timetable/MobileCourseSearchSheet.tsx
@@ -23,6 +23,7 @@ import { useEffectiveCourseFilters } from "@/stores/useCourseFilterStore";
 import {
   countActiveFilters,
   getOnlineTypeLabel,
+  getEnrollmentLabel,
 } from "@/components/mobile/timetable/filter/courseFilterModel";
 import { mapFilterToOfferingFilters } from "@/utils/courseSearchResult";
 import Skeleton from "@/components/common/Skeleton";
@@ -505,6 +506,10 @@ const MobileCourseSearchSheet = ({
                     course.ssupTypeName,
                     course.ssupTypeCode,
                   );
+                  const enrollmentLabel = getEnrollmentLabel(
+                    course.enrolledCount,
+                    course.capacity,
+                  );
 
                   return (
                     <CourseItem
@@ -523,12 +528,9 @@ const MobileCourseSearchSheet = ({
                               {course.savedCount}명 담음
                             </SavedBadge>
                           )}
-                          {course.enrolledCount != null &&
-                            course.capacity != null && (
-                              <EnrolledBadge>
-                                {course.enrolledCount}명 / {course.capacity}명
-                              </EnrolledBadge>
-                            )}
+                          {enrollmentLabel && (
+                            <EnrolledBadge>{enrollmentLabel}</EnrolledBadge>
+                          )}
                         </RightInfo>
                       </InfoRow>
 

--- a/src/components/mobile/timetable/filter/courseFilterModel.ts
+++ b/src/components/mobile/timetable/filter/courseFilterModel.ts
@@ -145,6 +145,18 @@ export function getOnlineTypeLabel(
   return ssupTypeName || ssupTypeCode || null;
 }
 
+// 정원/실제 수강 인원 배지 라벨. 값이 하나만 있어도(둘 다 있어야만 노출하던
+// all-or-nothing 대신) 있는 값만이라도 라벨과 함께 보여준다(#256).
+export function getEnrollmentLabel(
+  enrolledCount?: number | null,
+  capacity?: number | null,
+): string | null {
+  const parts: string[] = [];
+  if (capacity != null) parts.push(`정원 ${capacity}명`);
+  if (enrolledCount != null) parts.push(`수강 ${enrolledCount}명`);
+  if (parts.length === 0) return null;
+  return parts.join(" · ");
+}
 
 export const SORT_OPTIONS = ["기본순", "별점높은순", "담은인원많은순"] as const;
 export const TYPE_OPTIONS = ["전공", "교양", "교직", "일반선택", "군사학"] as const;

--- a/src/components/mobile/timetable/wizard/WizardCourseSearchSheet.tsx
+++ b/src/components/mobile/timetable/wizard/WizardCourseSearchSheet.tsx
@@ -27,6 +27,7 @@ import {
   FILTER_SUB_VIEW_TITLES,
   countActiveFilters,
   getOnlineTypeLabel,
+  getEnrollmentLabel,
 } from "@/components/mobile/timetable/filter/courseFilterModel";
 import { mapFilterToOfferingFilters } from "@/utils/courseSearchResult";
 import { toWizardCourseOption } from "@/utils/timetableWizardPool";
@@ -103,6 +104,7 @@ interface CourseRow {
   isMajor: boolean;
   isuLabel: string;
   onlineTypeLabel: string | null;
+  enrollmentLabel: string | null;
   timeStr: string;
   room: string;
   enrolledCount: number | null;
@@ -126,6 +128,10 @@ const buildCourseRow = (
     offering.ssupTypeName,
     offering.ssupTypeCode,
   );
+  const enrollmentLabel = getEnrollmentLabel(
+    offering.enrolledCount,
+    offering.capacity,
+  );
 
   return {
     offeringId: offering.id,
@@ -139,6 +145,7 @@ const buildCourseRow = (
     // 심화교양/교직/일반선택/군사학). 전공·교양 두 갈래로 뭉개면 실제와 어긋난다.
     isuLabel: isuName || "-",
     onlineTypeLabel,
+    enrollmentLabel,
     timeStr: offering.meetings
       .map((m) => `${DAY_LABELS[DAY_INDEX[m.day]]} ${m.startTime}~${m.endTime}`)
       .join(", "),
@@ -409,10 +416,8 @@ const WizardCourseSearchSheet = () => {
                                 {row.savedCount}명 담음
                               </SavedBadge>
                             )}
-                            {row.enrolledCount != null && row.capacity != null && (
-                              <EnrolledBadge>
-                                {row.enrolledCount}명 / {row.capacity}명
-                              </EnrolledBadge>
+                            {row.enrollmentLabel && (
+                              <EnrolledBadge>{row.enrollmentLabel}</EnrolledBadge>
                             )}
                           </RightInfo>
                         </InfoRow>


### PR DESCRIPTION
## 요약
`EnrolledBadge`가 "12명 / 40명"처럼 라벨 없이 숫자만 나열해 어느 쪽이 정원이고 어느 쪽이 실제 수강 인원인지 구분되지 않던 문제와, `capacity`/`enrolledCount` 중 하나라도 null이면 배지 전체가 사라지던 all-or-nothing 표시를 고칩니다.

## 변경 사항
- `courseFilterModel.ts`에 `getEnrollmentLabel` 추가 — "정원 N명 · 수강 N명" 형태로 라벨을 붙이고, 값이 하나만 있으면 있는 값만 표시합니다.
- `MobileCourseSearchSheet`, `WizardCourseSearchSheet` 양쪽에서 재사용.

## 범위 밖
- 이슈에서 함께 언급된 "담은 인원" 표시는 이미 별도로 구현/배포되어 있었습니다(`SavedBadge`, 커밋 b78d5d86/2e8b4edc) — 이번 PR은 정원/수강인원 라벨링만 다룹니다.
- 사용자 제보 값(#251)과의 출처 구분 표시는 #251 타당성 검토 결론 이후 별도 작업.

## 확인
- `tsc --noEmit`, `npm run build` 통과
- 변경 파일 대상 eslint(레거시 설정) 통과

Closes #256

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>