### PR TITLE
fix: 다음 학기 미리 등록 시 기본 학기 선택이 빈 미래 학기로 밀리는 문제 (#235)

### DIFF
--- a/src/components/mobile/timetable/GradeImportSheet.tsx
+++ b/src/components/mobile/timetable/GradeImportSheet.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { ChevronLeft } from "lucide-react";
 import CapsuleButton from "@/components/common/CapsuleButton";
 import { useSemesters } from "@/hooks/useSemesters";
+import { pickCurrentSemester } from "@/utils/semester";
 import { useCourses } from "@/hooks/useCourses";
 import useUserStore from "@/stores/useUserStore";
 import { parseSmartCampusGrades } from "@/utils/parseSmartCampusGrades";
@@ -78,8 +79,11 @@ export default function GradeImportSheet({
   // 하지 않는다.
   const effectiveSemester = useMemo(() => {
     if (detectedSemester) return detectedSemester;
-    if (semesters.length > 0) {
-      return { year: semesters[0].year, term: semesters[0].term };
+    // 진행중(OPEN) 학기를 우선한다 — 다음 학기가 개설강의 동기화 전에
+    // 미리 등록돼 있으면(#235) 최신 학기가 아직 텅 빈 학기일 수 있다.
+    const preferred = pickCurrentSemester(semesters);
+    if (preferred) {
+      return { year: preferred.year, term: preferred.term };
     }
     return null;
   }, [detectedSemester, semesters]);

--- a/src/pages/mobile/timetable/MobileTimeTableListPage.tsx
+++ b/src/pages/mobile/timetable/MobileTimeTableListPage.tsx
@@ -12,7 +12,7 @@ import {
   useUpdateTimeTablePrimary,
 } from "@/hooks/useTimeTables";
 import { useSemesters } from "@/hooks/useSemesters";
-import { formatSemester } from "@/utils/semester";
+import { formatSemester, pickCurrentSemester } from "@/utils/semester";
 import { mixpanelTrack } from "@/utils/mixpanel";
 
 // Icons
@@ -83,10 +83,14 @@ export default function MobileTimeTableListPage() {
   }, []);
 
   const handleAddClick = useCallback(() => {
-    if (semesters.length === 0) return;
+    // 목록(semesters[0])이 아니라 serverSemesters에서 진행중(OPEN) 학기를 직접
+    // 고른다 — 다음 학기가 미리 등록돼 있으면 semesters[0]이 아직 아무 시간표도
+    // 없어야 정상인 미래 학기가 될 수 있다(#235).
+    const preferred = pickCurrentSemester(serverSemesters);
+    if (!preferred) return;
     mixpanelTrack.timetableFeatureClicked("시간표 생성", "시간표 목록");
-    openAddModal(semesters[0]);
-  }, [openAddModal, semesters]);
+    openAddModal(formatSemester(preferred.year, preferred.term));
+  }, [openAddModal, serverSemesters]);
 
   const headerRight = useMemo(() => (
     <IconButton onClick={handleAddClick}>

--- a/src/pages/mobile/timetable/MobileTimetableWizardPage.tsx
+++ b/src/pages/mobile/timetable/MobileTimetableWizardPage.tsx
@@ -6,6 +6,7 @@ import { useHeader } from "@/context/HeaderContext";
 import CapsuleButton from "@/components/common/CapsuleButton";
 import Badge from "@/components/common/Badge";
 import { useSemesters } from "@/hooks/useSemesters";
+import { pickCurrentSemester } from "@/utils/semester";
 import useUserStore from "@/stores/useUserStore";
 import { ROUTES } from "@/constants/routes";
 import { appBridge, supportsMultiWebView } from "@/utils/appBridgeAdapter";
@@ -84,7 +85,8 @@ export default function MobileTimetableWizardPage() {
   useEffect(() => {
     if (semesters.length === 0) return;
     if (semester && semesters.some((s) => s.id === semester.id)) return;
-    const preferred = semesters.find((s) => s.status === "OPEN") ?? semesters[0];
+    const preferred = pickCurrentSemester(semesters);
+    if (!preferred) return;
     setSemester({ id: preferred.id, year: preferred.year, term: preferred.term });
   }, [semesters, semester, setSemester]);
 

--- a/src/utils/semester.ts
+++ b/src/utils/semester.ts
@@ -22,3 +22,15 @@ export const sortSemestersDesc = (semesters: Semester[]) =>
   [...semesters].sort(
     (a, b) => b.year - a.year || TERM_ORDER[b.term] - TERM_ORDER[a.term],
   );
+
+// 서버 학기 목록에서 "지금" 학기를 고른다. status가 OPEN인 학기를 우선하고,
+// 없으면(학기 전환기 등) 가장 최근 학기로 대체한다.
+//
+// semesters[0](정렬 후 최신 항목)을 그냥 쓰면 안 되는 이유: 다음 학기가 등록 시작
+// 전부터(과목 편람만 채워진 UPCOMING 상태로) 서버에 미리 들어올 수 있는데, 정렬은
+// status를 보지 않고 연도/학기 순서로만 매기므로 이 경우 semesters[0]이 아직 아무도
+// 쓰지 않는 미래 학기가 돼 버린다(#235).
+export const pickCurrentSemester = <T extends { status: Semester["status"] }>(
+  semesters: T[],
+): T | undefined =>
+  semesters.find((s) => s.status === "OPEN") ?? semesters[0];


### PR DESCRIPTION
## 요약
#235("전년도랑 추후 학기 추가되면 에지케이스 가능성 확인")를 조사한 결과 찾은 구체적인 버그입니다.

`useSemesters()`는 서버 학기 목록을 연도/학기 순으로만 정렬하고 `status`는 보지 않습니다. "가장 최근 학기"를 기본값으로 쓰는 화면들이 `semesters[0]`을 그대로 쓰면, 다음 학기가 개설강의 동기화 전에 미리(`UPCOMING` 상태로) 서버에 등록되는 순간 그 화면들의 기본값이 조용히 아직 아무 데이터도 없는 미래 학기로 넘어갑니다.

`MobileTimetableWizardPage.tsx`는 이미 `OPEN` 우선 로직을 인라인으로 정확히 갖고 있었는데, 같은 문제를 가진 다른 두 곳은 그렇지 않았습니다.

## 변경 사항
- `src/utils/semester.ts`: `pickCurrentSemester` 추가 — status가 `OPEN`인 학기를 우선하고 없으면 `semesters[0]`으로 대체.
- `MobileTimetableWizardPage.tsx`: 기존 인라인 로직을 공용 헬퍼로 교체(동작 변경 없음, 중복 제거).
- `GradeImportSheet.tsx`: 학기 미검출 시 개설강의 재조회용 fallback 학기를 `pickCurrentSemester`로 교체 — 코드 주석에 따르면 미래 학기엔 아직 개설강의가 없어, 애매한 매칭 행의 보강 조회가 조용히 실패할 수 있었습니다.
- `MobileTimeTableListPage.tsx`: 시간표 목록 "+"(생성) 버튼의 기본 학기도 동일 교체.

## 확인
- `tsc --noEmit`, `npm run build` 통과
- 변경 파일 대상 eslint(레거시 설정) 통과

Closes #235

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>