### PR TITLE
feat: 마법사 빈 결과 화면에서 충돌 강의 바로 빼고 재생성 (#248)

### DIFF
--- a/src/components/mobile/timetable/wizard/WizardEmptyErrorScreens.tsx
+++ b/src/components/mobile/timetable/wizard/WizardEmptyErrorScreens.tsx
@@ -7,9 +7,17 @@ import { formatCourseMeta } from "@/utils/timetableWizardFormat";
 interface WizardEmptyStateProps {
   conflicts: WizardConflictItem[];
   onRelax: () => void;
+  // 담은 강의끼리 시간이 겹치는 conflict(courses가 채워진 경우, 항상 위시리스트
+  // 항목이다 - timetableWizardGenerator.ts의 findOverlappingRequiredPairs 참고)를
+  // 이 화면에서 바로 뺄 수 있게 한다. 없으면(레거시 호출부) 빼기 버튼을 숨긴다.
+  onRemoveWishlistCourse?: (subjectNumber: string) => void;
 }
 
-export function WizardEmptyState({ conflicts, onRelax }: WizardEmptyStateProps) {
+export function WizardEmptyState({
+  conflicts,
+  onRelax,
+  onRemoveWishlistCourse,
+}: WizardEmptyStateProps) {
   return (
     <Wrapper>
       <Body>
@@ -27,9 +35,21 @@ export function WizardEmptyState({ conflicts, onRelax }: WizardEmptyStateProps) 
                   {c.courses && c.courses.length > 0 && (
                     <ConflictCourseList>
                       {c.courses.map((course, courseIndex) => (
-                        <ConflictCourse key={courseIndex}>
-                          {course.title} ({formatCourseMeta(course)})
-                        </ConflictCourse>
+                        <ConflictCourseRow key={courseIndex}>
+                          <ConflictCourse>
+                            {course.title} ({formatCourseMeta(course)})
+                          </ConflictCourse>
+                          {onRemoveWishlistCourse && (
+                            <ConflictCourseRemoveButton
+                              type="button"
+                              onClick={() =>
+                                onRemoveWishlistCourse(course.subjectNumber)
+                              }
+                            >
+                              빼기
+                            </ConflictCourseRemoveButton>
+                          )}
+                        </ConflictCourseRow>
                       ))}
                     </ConflictCourseList>
                   )}
@@ -166,10 +186,29 @@ const ConflictCourseList = styled.div`
   padding-left: 12px;
 `;
 
+const ConflictCourseRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+`;
+
 const ConflictCourse = styled.span`
   font-size: 12px;
   line-height: 18px;
   word-break: break-all;
+`;
+
+const ConflictCourseRemoveButton = styled.button`
+  flex-shrink: 0;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-default, #e5e8eb);
+  background: var(--bg-base, #ffffff);
+  color: var(--text-secondary, #4e5968);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 16px;
 `;
 
 const ConflictFootnote = styled.span`

--- a/src/pages/mobile/timetable/MobileTimetableWizardPage.tsx
+++ b/src/pages/mobile/timetable/MobileTimetableWizardPage.tsx
@@ -130,6 +130,16 @@ export default function MobileTimetableWizardPage() {
 
   const runGeneration = useCallback(() => setStep("generating"), [setStep]);
 
+  // 빈 결과 화면에서 원인 강의를 바로 빼고 그 자리에서 재생성한다(#248). Step1로
+  // 돌아가 사용자가 직접 어떤 강의였는지 기억해 빼야 했던 흐름을 없앤다.
+  const handleRemoveWishlistCourseFromConflict = useCallback(
+    (subjectNumber: string) => {
+      removeWishlistCourse(subjectNumber);
+      runGeneration();
+    },
+    [removeWishlistCourse, runGeneration],
+  );
+
   const selectedCandidate = useMemo(
     () => result?.candidates.find((c) => c.id === selectedCandidateId) ?? null,
     [result, selectedCandidateId],
@@ -327,7 +337,11 @@ export default function MobileTimetableWizardPage() {
       )}
 
       {step === "empty" && result && (
-        <WizardEmptyState conflicts={result.conflicts} onRelax={() => setStep("step1")} />
+        <WizardEmptyState
+          conflicts={result.conflicts}
+          onRelax={() => setStep("step1")}
+          onRemoveWishlistCourse={handleRemoveWishlistCourseFromConflict}
+        />
       )}
 
       {step === "error" && <WizardErrorState onRetry={runGeneration} />}


### PR DESCRIPTION
## 요약
조합 실패("빈 결과") 화면에서 문제가 된 강의를 확인해도 할 수 있는 건 "조건 완화하기"로 Step1에 돌아가는 것뿐이었습니다. 이 PR은 담은 강의끼리 시간이 겹쳐 실패한 경우, 그 자리에서 원인 강의를 빼고 바로 재생성할 수 있게 합니다.

## 변경 사항
- `courses`가 채워진 conflict(담은 강의끼리 시간 겹침)는 `findOverlappingRequiredPairs`가 위시리스트 항목만 채우므로(제외 강의 conflict는 `courses` 없이 `label`만 있음) 항상 위시리스트 항목입니다 — "빼기" 버튼을 안전하게 `removeWishlistCourse`에 연결했습니다.
- `WizardEmptyState`에 `onRemoveWishlistCourse` prop 추가(옵셔널, 없으면 기존처럼 버튼 없이 렌더링).
- `MobileTimetableWizardPage`: 제거 즉시 `runGeneration()`으로 이어붙여 같은 화면에서 재생성까지 흐릅니다(위시리스트가 강의 스냅샷을 갖고 있어 서버 조회 없는 순수 계산이라 즉시 재계산됨).

## 범위 밖
- "교체"(다른 분반으로 바꾸기) 진입점은 포함하지 않았습니다 — 과목 검색 시트를 특정 과목으로 필터링해서 여는 부분은 별도 조사가 필요해 후속 작업으로 남겨둡니다.
- "제외한 강의" 충돌은 애초에 구체적인 과목 목록을 안 주므로(label만) 이번 빼기 버튼의 대상이 아닙니다.

## 확인
- `tsc --noEmit`, `npm run build` 통과
- 변경 파일 대상 eslint(레거시 설정) 통과

부분 해결 — "교체" 항목이 남아 있어 이 PR은 이슈를 자동으로 닫지 않습니다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>