### PR TITLE
fix: 친구 대표 시간표 응답이 요청 학기와 다르면 방어적으로 숨김 (#267)

### DIFF
--- a/src/pages/mobile/timetable/MobileTimeTableComparePage.tsx
+++ b/src/pages/mobile/timetable/MobileTimeTableComparePage.tsx
@@ -15,7 +15,7 @@ import { useTimetableStore } from "@/stores/useTimetableStore";
 import { useTimeTableDetail, useTimeTables } from "@/hooks/useTimeTables";
 import { mapDetailItemsToClassItems } from "@/utils/timetable";
 import { mixpanelTrack } from "@/utils/mixpanel";
-import type { TimeTableDetail } from "@/types/timetables";
+import type { TimeTableDetail, Term } from "@/types/timetables";
 import { useSemesters } from "@/hooks/useSemesters";
 import { formatSemester } from "@/utils/semester";
 import useUserStore from "@/stores/useUserStore";
@@ -45,6 +45,19 @@ const isProtectedTimetable = (detail: TimeTableDetail) =>
     const source = item.course ?? item.customSchedule;
     return item.id == null || source?.title == null;
   });
+
+// 응답 유효성 방어 로직(#267). 서버의 "대표 시간표 자동 승격"이 아직 미완성이라
+// (server #328), /friends/{id}/primary가 요청한 학기와 다른 학기의 시간표를
+// 잘못 대표로 내려줄 가능성을 프론트에서 감지한다. 그대로 표시하면 "이 사람이
+// 신청한 이번 학기 시간표"처럼 보이지만 실제로는 다른 학기 데이터라 완전히
+// 틀린 정보를 신뢰도 있게 보여주는 셈이 된다 - 차라리 에러로 처리해 숨긴다.
+const isSemesterMismatch = (
+  detail: TimeTableDetail,
+  requested: { year?: number; term?: Term } | null | undefined,
+) =>
+  requested?.year != null &&
+  requested?.term != null &&
+  (detail.year !== requested.year || detail.term !== requested.term);
 
 const getErrorStatus = (error: unknown) =>
   (error as { response?: { status?: number } })?.response?.status;
@@ -168,12 +181,17 @@ export default function MobileTimeTableComparePage() {
   const friendTimetablesByFriendId = useMemo(() => {
     const entries = queriedFriends.map((friend, index) => {
       const detail = friendTimetableQueries[index]?.data;
-      const classes = detail ? mapDetailItemsToClassItems(detail.items) : [];
+      // 학기가 어긋난 응답은 그리드에도 올리지 않는다 - 상태만 ERROR로 감춰도
+      // 이 맵에서 걸러지지 않으면 블록은 그대로 그려진다.
+      const classes =
+        detail && !isSemesterMismatch(detail, openSemester)
+          ? mapDetailItemsToClassItems(detail.items)
+          : [];
       return [friend.friendId, classes] as const;
     });
 
     return new Map(entries);
-  }, [queriedFriends, friendTimetableQueries]);
+  }, [queriedFriends, friendTimetableQueries, openSemester]);
 
   const friendTimetableStatesByFriendId = useMemo(() => {
     const entries = queriedFriends.map((friend, index) => {
@@ -183,6 +201,16 @@ export default function MobileTimeTableComparePage() {
 
       if (query?.isPending) {
         state = "LOADING";
+      } else if (detail && isSemesterMismatch(detail, openSemester)) {
+        console.warn(
+          "친구 대표 시간표 응답이 요청한 학기와 다릅니다(server #328 관련 방어 로직, #267):",
+          {
+            friendId: friend.friendId,
+            requested: openSemester,
+            received: { year: detail.year, term: detail.term },
+          },
+        );
+        state = "ERROR";
       } else if (detail) {
         state = isProtectedTimetable(detail) ? "PROTECTED" : "PUBLIC";
       } else {
@@ -195,7 +223,7 @@ export default function MobileTimeTableComparePage() {
     });
 
     return new Map(entries);
-  }, [queriedFriends, friendTimetableQueries]);
+  }, [queriedFriends, friendTimetableQueries, openSemester]);
 
   const activeFriends = useMemo(() => {
     // 쿼리로 들어온 ID에 매칭되는 친구 필터링


### PR DESCRIPTION
## 요약
server #328(대표 시간표 자동 승격)이 아직 미완성이라, `/friends/{id}/primary`가 요청한 학기와 다른 학기의 시간표를 대표로 잘못 내려줄 가능성이 있습니다. 이 PR은 근본 원인(서버)을 고치지 못하지만, 프론트가 틀린 데이터를 진짜인 것처럼 보여주지는 않게 막습니다 — 이슈 본문의 (선택) 방어 로직 항목을 반영합니다.

## 변경 사항
- `isSemesterMismatch(detail, requested)` 추가 — 응답의 `year`/`term`이 요청한 `openSemester`와 다르면 감지합니다.
- 어긋나면 상태를 `ERROR`로 처리하고, 그리드에도 올리지 않습니다(상태만 감춰도 별도 map이 items를 올리면 블록은 그대로 그려지므로 둘 다 막았습니다).
- `console.warn`으로 friendId/요청 학기/응답 학기를 남겨 재현 시 서버 조사에 바로 쓸 수 있게 했습니다.

## 이슈를 닫지 않는 이유
근본 해결은 여전히 server #328입니다. 이 PR은 방어막일 뿐이고, 이 방어 로직이 실제로 발동하는지(콘솔 경고가 찍히는지)로 문제 재현 여부를 간접 확인하는 용도로도 쓸 수 있습니다.

## 확인
- `tsc --noEmit`, `npm run build` 통과
- 변경 파일 대상 eslint(레거시 설정) — 기존 `no-explicit-any` 오류 3건은 이번 변경과 무관(사전 존재, 다른 함수)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>