### PR TITLE
feat: 채팅방 내부에 공강 맞추기 버튼 추가 (#264)

### DIFF
--- a/src/pages/mobile/ChattingPage.tsx
+++ b/src/pages/mobile/ChattingPage.tsx
@@ -36,6 +36,7 @@ const getMessageColor = (identifier: string) => {
 };
 
 import { updateChatRoomTitle, getChatRoomMembers } from "@/apis/chat";
+import { getFriends } from "@/apis/friends";
 import useUserStore from "@/stores/useUserStore";
 import { ROUTES } from "@/constants/routes";
 import EditChatRoomTitleModal from "@/components/mobile/chat/EditChatRoomTitleModal";
@@ -160,6 +161,48 @@ export default function ChattingPage() {
   });
   const members = membersRes?.data || [];
 
+  // "공강 맞추기"(#264)에서만 쓰인다. 채팅방 멤버 API는 friendMemberId를 안 주므로
+  // 친구 목록과 studentId/nickname으로 대조해야 시간표 조회에 쓸 friendMemberId를
+  // 얻을 수 있다(MemberListDrawer.tsx의 매칭 방식과 동일).
+  const { data: friendsRes } = useQuery({
+    queryKey: ["friends"],
+    queryFn: getFriends,
+  });
+  const friends = friendsRes?.data || [];
+
+  const handleFindFreeTime = () => {
+    const nonSelfMembers = members.filter((m) => !m.isMe);
+    const matchedFriendMemberIds = nonSelfMembers
+      .map(
+        (m) =>
+          friends.find(
+            (f) =>
+              (m.studentId && m.studentId === f.studentId) ||
+              m.nickname === f.nickname,
+          )?.friendMemberId,
+      )
+      .filter((id): id is number => id != null);
+
+    if (matchedFriendMemberIds.length === 0) {
+      alert(
+        "친구로 등록된 참여자가 없어 공강을 계산할 수 없어요. 먼저 친구를 추가해 주세요.",
+      );
+      return;
+    }
+    if (matchedFriendMemberIds.length < nonSelfMembers.length) {
+      alert(
+        "친구가 아닌 참여자는 제외하고, 친구로 등록된 참여자만 시간표를 비교해요.",
+      );
+    }
+
+    mixpanelTrack.chatRoomMenuClicked("공강 맞추기", roomId ?? "");
+    const params = new URLSearchParams();
+    params.set("memberIds", matchedFriendMemberIds.join(","));
+    params.set("tab", "free");
+    if (roomId) params.set("roomId", roomId);
+    navigate(`${ROUTES.TIMETABLE.COMPARE}?${params.toString()}`);
+  };
+
   useVisualViewport();
 
   const handleUpdateTitle = () => {
@@ -261,8 +304,13 @@ export default function ChattingPage() {
       });
     }
 
+    items.push({
+      label: "공강 맞추기",
+      onClick: handleFindFreeTime,
+    });
+
     return items;
-  }, [roomInfo, isAdmin]);
+  }, [roomInfo, isAdmin, members, friends]);
 
   useHeader({
     title: headerTitle,

--- a/src/pages/mobile/timetable/MobileTimeTableComparePage.tsx
+++ b/src/pages/mobile/timetable/MobileTimeTableComparePage.tsx
@@ -83,6 +83,9 @@ export default function MobileTimeTableComparePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const friendIdsParam = searchParams.get("ids") || "";
   const memberIdsParam = searchParams.get("memberIds") || "";
+  // 채팅방 내부의 "공강 맞추기" 버튼(#264)에서 진입한 경우에만 채워진다. 있으면
+  // "공유"가 새 채팅방을 만드는 대신 이 방으로 바로 공유한다.
+  const originRoomId = searchParams.get("roomId") || "";
   const { userInfo } = useUserStore();
   const { activeTimetableId, timetables } = useTimetableStore();
 
@@ -843,6 +846,32 @@ export default function MobileTimeTableComparePage() {
     return `선택한 ${topNames} 님 외 ${extraCount}명 단체톡방에 공유할까요?`;
   }, [selectedFriendIdsState, searchParams, friendsMap]);
 
+  const buildTimetableSharePayload = (
+    targetFriendIds: number[],
+  ): TimetableShareExtraData => ({
+    title: "시간표 겹쳐보기 & 공강 공유",
+    friendIds: targetFriendIds,
+    memberIds: [
+      userInfo.id,
+      ...targetFriendIds
+        .map(
+          (friendId) =>
+            friendsMap.find((friend) => friend.friendId === friendId)
+              ?.friendMemberId,
+        )
+        .filter((memberId): memberId is number => memberId != null),
+    ].filter(
+      (memberId, index, ids) =>
+        memberId > 0 && ids.indexOf(memberId) === index,
+    ),
+    topFreeTimes: goodMeetingTimes.slice(0, 3).map((slot) => ({
+      day: slot.day,
+      startTime: slot.startTime,
+      endTime: slot.endTime,
+      duration: slot.duration,
+    })),
+  });
+
   const shareMutation = useMutation({
     mutationFn: async (targetFriendIds: number[]) =>
       createPersonalChatRoom(targetFriendIds),
@@ -855,29 +884,7 @@ export default function MobileTimeTableComparePage() {
       const roomData = res.data || res;
       const roomId = roomData.id || roomData.roomId;
       if (roomId) {
-        const payload: TimetableShareExtraData = {
-          title: "시간표 겹쳐보기 & 공강 공유",
-          friendIds: variables,
-          memberIds: [
-            userInfo.id,
-            ...variables
-              .map(
-                (friendId) =>
-                  friendsMap.find((friend) => friend.friendId === friendId)
-                    ?.friendMemberId,
-              )
-              .filter((memberId): memberId is number => memberId != null),
-          ].filter(
-            (memberId, index, ids) =>
-              memberId > 0 && ids.indexOf(memberId) === index,
-          ),
-          topFreeTimes: goodMeetingTimes.slice(0, 3).map((slot) => ({
-            day: slot.day,
-            startTime: slot.startTime,
-            endTime: slot.endTime,
-            duration: slot.duration,
-          })),
-        };
+        const payload = buildTimetableSharePayload(variables);
         const payloadStr = encodeURIComponent(JSON.stringify(payload));
         navigate(`${ROUTES.CHAT.ROOT}/${roomId}?sharePayload=${payloadStr}`);
       }
@@ -918,6 +925,21 @@ export default function MobileTimeTableComparePage() {
           .filter((id) => Boolean(id) && id !== 99999);
       }
     }
+
+    // 채팅방 "공강 맞추기" 버튼으로 들어온 경우, 새 채팅방을 만들지 않고 원래
+    // 있던 그 방으로 바로 공유한다(#264 목표 상태의 마지막 항목).
+    if (originRoomId) {
+      setIsConfirmModalOpen(false);
+      mixpanelTrack.timetableCompareAction("공유", {
+        friend_count: targetIds.length,
+        free_slot_count: goodMeetingTimes.length,
+      });
+      const payload = buildTimetableSharePayload(targetIds);
+      const payloadStr = encodeURIComponent(JSON.stringify(payload));
+      navigate(`${ROUTES.CHAT.ROOT}/${originRoomId}?sharePayload=${payloadStr}`);
+      return;
+    }
+
     shareMutation.mutate(targetIds);
   };
 


### PR DESCRIPTION
## 요약
원래 스펙(web #216)은 "톡방 안에서 시작"이었는데 실제 구현은 역방향(친구 목록 → 비교 → 채팅방에 공유)뿐이었습니다. 채팅방 메뉴에 진입점을 추가합니다.

## 변경 사항
- `ChattingPage` 메뉴에 "공강 맞추기" 항목 추가.
- 채팅방 멤버 API(`getChatRoomMembers`)는 `friendMemberId`를 안 주므로, `MemberListDrawer.tsx`와 동일한 방식(studentId, 없으면 nickname)으로 내 친구 목록과 대조해 `friendMemberId`를 얻습니다.
- 채팅방 참여자가 항상 친구는 아니라는 이슈의 우려대로, 친구가 아닌 참여자는 시간표를 가져올 방법이 없습니다(`getFriendPrimaryTimeTableDetail`은 친구 관계 전제) — 친구로 매칭된 인원만 비교 화면(공강 탭)으로 넘기고, 제외된 인원이 있으면 안내 알럿을 띄웁니다. 매칭된 친구가 0명이면 진입을 막습니다.
- `MobileTimeTableComparePage`: `roomId` 쿼리 파라미터 추가. 있으면(이 버튼으로 들어온 경우) "공유" 클릭 시 새 채팅방을 만드는 대신 원래 있던 그 방으로 바로 공유합니다(목표 상태 체크리스트의 마지막 항목) — 기존 "친구 목록에서 시작" 플로우(roomId 없음)는 그대로 `createPersonalChatRoom` 경로를 타서 동작 변경이 없습니다.
- 페이로드 구성 로직을 `buildTimetableSharePayload`로 추출해 두 경로가 공유합니다.

## 알려진 제약
- 친구가 아닌 채팅방 참여자의 시간표는 여전히 가져올 수 없습니다(서버에 임의 회원 시간표 조회 권한 체계가 없음) — `inu-appcenter/inu-portal-server#340` 참고, 이 PR 범위 밖입니다.
- `goodMeetingTimes` 계산 로직 자체를 재사용 가능한 훅으로 추출하는 리팩터는 하지 않았습니다 — 이 흐름은 비교 화면으로 그대로 이동시켜 기존 계산을 재사용하므로(쿼리 파라미터로 대상만 넘김) 별도 추출 없이도 중복이 생기지 않습니다.

## 확인
- `tsc --noEmit`, `npm run build` 통과
- eslint(레거시 설정): `ChattingPage.tsx`의 `menuItems` useMemo에 React Compiler `preserve-manual-memoization` 경고가 뜨는데, 같은 파일에 `dev` 기준으로도 이미 있던 동일 패턴(비메모이즈 핸들러를 useMemo 안에서 호출)이 제 변경으로 한 항목 늘어난 것입니다 — 새 카테고리의 오류는 아니며, 이 저장소의 `npm run lint` 자체가 현재 실행되지 않는 상태(eslint 9 + flat config 없음)라 CI가 잡아내는 종류도 아닙니다.

Closes #264

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>