### PR TITLE
feat: 시간표 비교 화면에서 내 일정 바로 추가 (#265)

### DIFF
--- a/src/pages/mobile/timetable/MobileTimeTableComparePage.tsx
+++ b/src/pages/mobile/timetable/MobileTimeTableComparePage.tsx
@@ -28,7 +28,7 @@ import TimetableGrid, {
 } from "@/components/mobile/timetable/TimetableGrid";
 
 // 아이콘
-import { Plus, Send } from "lucide-react";
+import { Plus, Send, CalendarPlus } from "lucide-react";
 
 const DAYS_KOREAN = ["월요일", "화요일", "수요일", "목요일", "금요일"];
 
@@ -87,7 +87,8 @@ export default function MobileTimeTableComparePage() {
   // "공유"가 새 채팅방을 만드는 대신 이 방으로 바로 공유한다.
   const originRoomId = searchParams.get("roomId") || "";
   const { userInfo } = useUserStore();
-  const { activeTimetableId, timetables } = useTimetableStore();
+  const { activeTimetableId, timetables, setActiveTimetable } =
+    useTimetableStore();
 
   const chipScrollRef = useRef<HTMLDivElement | null>(null);
   const [hasHorizontalOverflow, setHasHorizontalOverflow] = useState(false);
@@ -136,6 +137,25 @@ export default function MobileTimeTableComparePage() {
   }, [timetables, activeTimetableId, openSemester]);
 
   useTimeTableDetail(activeTimetable?.id);
+
+  // "내 일정 추가"(#265). 이 화면에 표시 중인 시간표(activeTimetable)가 전역
+  // activeTimetableId와 다를 수 있어(학기가 다르면 대표 시간표나 목록의 첫 항목으로
+  // 대체됨, 위 useMemo 참고) 기존 "일정 추가" 화면(MobileCourseAddPage)으로 그냥
+  // 이동하면 전역 activeTimetableId 기준으로 저장돼 여기서 보고 있던 시간표가
+  // 아닌 다른 시간표에 저장될 수 있다. 이동 전 전역 상태를 이 화면 기준으로
+  // 맞춰준다 - setActiveTimetable은 서버에 반영되는 "대표 시간표" 지정과는 무관한
+  // 로컬 UI 선택값이라 부작용이 적다.
+  const handleAddMySchedule = () => {
+    if (!activeTimetable) {
+      alert("먼저 이 학기의 시간표를 만들어 주세요.");
+      return;
+    }
+    if (activeTimetable.id !== activeTimetableId) {
+      setActiveTimetable(activeTimetable.id);
+    }
+    mixpanelTrack.timetableFeatureClicked("내 일정 추가", "시간표 비교");
+    navigate(ROUTES.TIMETABLE.ADD);
+  };
 
   const myClasses = useMemo(
     () =>
@@ -988,6 +1008,21 @@ export default function MobileTimeTableComparePage() {
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
+                  handleAddMySchedule();
+                }}
+                onTouchEnd={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleAddMySchedule();
+                }}
+                aria-label="내 일정 추가"
+              >
+                <CalendarPlus size={18} strokeWidth={2} />
+              </AddFriendButton>
+              <AddFriendButton
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
                   const allFriendIds = searchParams.get("ids") || "";
                   navigate(
                     allFriendIds
@@ -1005,6 +1040,7 @@ export default function MobileTimeTableComparePage() {
                       : ROUTES.FRIEND.LIST,
                   );
                 }}
+                aria-label="친구 추가/선택"
               >
                 <Plus size={18} strokeWidth={2} />
               </AddFriendButton>


### PR DESCRIPTION
## 요약
비교 화면(겹쳐보기/공강)은 이미 내 대표 시간표를 자동으로 불러와 보여주지만("가져오기"는 이미 됨), 웬투밋처럼 그 자리에서 내 가용시간을 추가하는 상호작용은 없었습니다.

## 이게 지금 가능해진 이유
PR #239(일정 추가 화면 개편)가 이미 dev에 병합되어 있고, #263 수정으로 멀티 웹뷰 환경에서도 정상 동작함을 확인했습니다. 커스텀 일정 생성 401 블로커(server #278/#279)가 실제로 여전히 막혀 있는지는 실기기로 재현하지 못했지만, #239/#263가 이미 같은 생성 API 경로를 전제로 배포되어 있는 것으로 보아 더는 블로커가 아닐 가능성이 높습니다.

## 정책 결정 (이슈에서 요구한 항목)
"임시 가용시간"이 아니라 **실제 내 시간표에 그대로 저장**하는 쪽을 택했습니다. 별도의 임시/휘발성 상태를 새로 설계하는 대신 이미 있는 "일정 추가" 화면과 저장 로직을 재사용할 수 있고, 사용자 입장에서도 자연스럽다고 판단했습니다.

## 구현
- 비교 화면 우측 액션 그룹에 "내 일정 추가" 버튼(`CalendarPlus`)을 기존 "친구 추가" 버튼 옆에 추가.
- 비교 화면의 `activeTimetable`은 전역 `activeTimetableId`와 다를 수 있어(학기가 다르면 대표 시간표/목록 첫 항목으로 대체), 이동 전 `setActiveTimetable`로 전역 상태를 화면에 보이는 시간표 기준으로 맞춥니다. 이 setter는 서버 "대표 시간표" 지정과 무관한 로컬 UI 선택값이라 부작용이 적습니다.
- 저장 후 기존 "일정 추가" 화면이 `navigate(-1)`로 돌아오므로 별도 콜백 없이 비교 화면으로 복귀, `useTimeTables()`가 이미 불러온 상태라 새 일정이 자연스럽게 반영됩니다.

## 확인 못한 것 — 후속 QA 필요 (중요)
- 실기기·실제 로그인 세션에서 "추가 → 저장 → 비교 화면 복귀 → 공강 계산에 반영" 전체 흐름의 육안 확인을 이번 세션 환경에서 하지 못했습니다.
- 커스텀 일정 생성 API가 실제로 401 없이 성공하는지도 실기기 확인이 필요합니다 — 만약 여전히 막혀 있다면 이 버튼은 에러 알럿만 띄우고 끝나며(기존 "일정 추가" 화면의 에러 처리를 그대로 상속), 이 PR이 회귀를 만들지는 않습니다.

## 확인
- `tsc --noEmit`, `npm run build` 통과
- eslint(레거시 설정) — 기존 `no-explicit-any` 오류 3건은 사전 존재, 이번 변경과 무관

Closes #265

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>