### PR TITLE
feat: 마법사 빈 결과 화면에서 충돌 강의 "교체" 진입점 추가 (#248 나머지 절반)

### DIFF
--- a/src/components/mobile/timetable/wizard/WizardEmptyErrorScreens.tsx
+++ b/src/components/mobile/timetable/wizard/WizardEmptyErrorScreens.tsx
@@ -1,7 +1,10 @@
 import styled from "styled-components";
 import CapsuleButton from "@/components/common/CapsuleButton";
 import 안내횃불이 from "@/resources/assets/book/안내횃불이.png";
-import type { WizardConflictItem } from "@/types/timetableWizard";
+import type {
+  WizardConflictItem,
+  WizardCourseOption,
+} from "@/types/timetableWizard";
 import { formatCourseMeta } from "@/utils/timetableWizardFormat";
 
 interface WizardEmptyStateProps {
@@ -11,12 +14,16 @@ interface WizardEmptyStateProps {
   // 항목이다 - timetableWizardGenerator.ts의 findOverlappingRequiredPairs 참고)를
   // 이 화면에서 바로 뺄 수 있게 한다. 없으면(레거시 호출부) 빼기 버튼을 숨긴다.
   onRemoveWishlistCourse?: (subjectNumber: string) => void;
+  // 같은 과목의 다른 분반으로 바꾸고 싶을 때 - 원인 강의를 빼고 그 과목명으로
+  // 미리 필터링된 강의 검색 시트를 연다.
+  onReplaceWishlistCourse?: (course: WizardCourseOption) => void;
 }
 
 export function WizardEmptyState({
   conflicts,
   onRelax,
   onRemoveWishlistCourse,
+  onReplaceWishlistCourse,
 }: WizardEmptyStateProps) {
   return (
     <Wrapper>
@@ -39,16 +46,28 @@ export function WizardEmptyState({
                           <ConflictCourse>
                             {course.title} ({formatCourseMeta(course)})
                           </ConflictCourse>
-                          {onRemoveWishlistCourse && (
-                            <ConflictCourseRemoveButton
-                              type="button"
-                              onClick={() =>
-                                onRemoveWishlistCourse(course.subjectNumber)
-                              }
-                            >
-                              빼기
-                            </ConflictCourseRemoveButton>
-                          )}
+                          <ConflictCourseActions>
+                            {onReplaceWishlistCourse && (
+                              <ConflictCourseRemoveButton
+                                type="button"
+                                onClick={() =>
+                                  onReplaceWishlistCourse(course)
+                                }
+                              >
+                                교체
+                              </ConflictCourseRemoveButton>
+                            )}
+                            {onRemoveWishlistCourse && (
+                              <ConflictCourseRemoveButton
+                                type="button"
+                                onClick={() =>
+                                  onRemoveWishlistCourse(course.subjectNumber)
+                                }
+                              >
+                                빼기
+                              </ConflictCourseRemoveButton>
+                            )}
+                          </ConflictCourseActions>
                         </ConflictCourseRow>
                       ))}
                     </ConflictCourseList>
@@ -191,6 +210,13 @@ const ConflictCourseRow = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+`;
+
+const ConflictCourseActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
 `;
 
 const ConflictCourse = styled.span`

--- a/src/pages/mobile/timetable/MobileTimetableWizardPage.tsx
+++ b/src/pages/mobile/timetable/MobileTimetableWizardPage.tsx
@@ -29,7 +29,10 @@ import {
   WizardErrorState,
 } from "@/components/mobile/timetable/wizard/WizardEmptyErrorScreens";
 import { formatCourseMeta } from "@/utils/timetableWizardFormat";
-import type { WizardPreferenceConditions } from "@/types/timetableWizard";
+import type {
+  WizardPreferenceConditions,
+  WizardCourseOption,
+} from "@/types/timetableWizard";
 
 const GENERATING_MIN_VISIBLE_MS = 1600;
 const DAY_LABELS = ["월", "화", "수", "목", "금"];
@@ -138,6 +141,20 @@ export default function MobileTimetableWizardPage() {
       runGeneration();
     },
     [removeWishlistCourse, runGeneration],
+  );
+
+  // 원인 강의를 다른 분반으로 "교체"한다(#248). 강의 자체를 빼고, 같은 과목명으로
+  // 미리 필터링된 검색 시트를 열어 다른 분반을 바로 담을 수 있게 한다. 시트에서
+  // 담은 뒤 재생성은 자동으로 이어지지 않는다 - 사용자가 몇 개를 더 조정할지
+  // 스스로 판단해야 하는 흐름(빈 결과 화면과 달리 여기서는 몇 번이고 검색/담기를
+  // 반복할 수 있음)이라, 매번 자동 재생성하면 오히려 방해가 된다. 다 고른 뒤
+  // "다시 만들기"로 직접 재생성한다.
+  const handleReplaceWishlistCourseFromConflict = useCallback(
+    (course: WizardCourseOption) => {
+      removeWishlistCourse(course.subjectNumber);
+      openCourseSearch("wishlist", course.title);
+    },
+    [removeWishlistCourse, openCourseSearch],
   );
 
   const selectedCandidate = useMemo(
@@ -341,6 +358,7 @@ export default function MobileTimetableWizardPage() {
           conflicts={result.conflicts}
           onRelax={() => setStep("step1")}
           onRemoveWishlistCourse={handleRemoveWishlistCourseFromConflict}
+          onReplaceWishlistCourse={handleReplaceWishlistCourseFromConflict}
         />
       )}
 

--- a/src/stores/useTimetableWizardStore.ts
+++ b/src/stores/useTimetableWizardStore.ts
@@ -117,7 +117,9 @@ interface WizardActions {
   closeSaveSheet: () => void;
 
   // --- 강의 검색 시트 ---
-  openCourseSearch: (target: CourseSearchTarget) => void;
+  // initialKeyword: 빈 결과 화면의 "교체" 버튼(#248)에서, 원인이 된 과목명으로
+  // 미리 필터링한 채로 열기 위해 쓴다. 생략하면 기존처럼 빈 검색어로 연다.
+  openCourseSearch: (target: CourseSearchTarget, initialKeyword?: string) => void;
   closeCourseSearch: () => void;
   setSearchSnapIndex: (index: number) => void;
   toggleExpandedOffering: (offeringId: number) => void;
@@ -283,7 +285,7 @@ export const useTimetableWizardStore = create<TimetableWizardStore>()(
 
       closeSaveSheet: () => set({ isSaveSheetOpen: false }),
 
-      openCourseSearch: (target) =>
+      openCourseSearch: (target, initialKeyword) =>
         set((state) => ({
           search: {
             ...state.search,
@@ -292,7 +294,7 @@ export const useTimetableWizardStore = create<TimetableWizardStore>()(
             // 조건이므로 유지 - 이게 사용자가 기대하는 유일한 "기억"이다.
             snapIndex: WIZARD_SEARCH_DEFAULT_SNAP_INDEX,
             expandedOfferingId: null,
-            keyword: "",
+            keyword: initialKeyword ?? "",
             filterDraft: null,
           },
         })),


### PR DESCRIPTION
## 요약
PR #309가 "빼기"를 구현했지만 "교체"(다른 분반으로 바꾸기)는 남겨뒀습니다. 이번에 마저 구현합니다.

## 변경 사항
- `useTimetableWizardStore`: `openCourseSearch(target, initialKeyword?)` — 검색 시트를 열 때 검색어를 미리 채울 수 있게 합니다. 생략 시 기존처럼 빈 검색어(기존 호출부는 전부 변경 없음).
- `WizardEmptyState`: 원인 강의별로 "교체"/"빼기" 버튼을 나란히 보여줍니다. "교체"는 그 강의를 위시리스트에서 빼고, 같은 과목명으로 미리 필터링된 강의 검색 시트를 엽니다.

## 자동 재생성을 붙이지 않은 이유
"빼기"는 사용자가 결정할 게 없어(그냥 없앰) 즉시 재생성해도 자연스럽지만, "교체"는 시트에서 몇 개를 더 담을지 사용자가 판단하는 흐름이라 매번 자동 재생성하면 오히려 방해가 됩니다. 다 고른 뒤 기존 "다시 만들기" 버튼으로 재생성합니다.

## 확인
- `tsc --noEmit`, `npm run build` 통과
- 변경 파일 대상 eslint(레거시 설정) 통과 — 새 경고/오류 없음
- 마법사 관련 유닛 테스트(`timetableWizardGenerator`, `timetableWizardFormat`) 11개 통과

이제 #248의 목표 상태 체크리스트 3개 항목 모두 다뤄졌습니다. 이 PR 머지 후 #248을 닫겠습니다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>