### PR TITLE
feat: 시간표 목록 화면에 이름 변경/삭제 관리 동작 추가 (#252)

### DIFF
--- a/src/pages/mobile/timetable/MobileTimeTableListPage.tsx
+++ b/src/pages/mobile/timetable/MobileTimeTableListPage.tsx
@@ -5,11 +5,16 @@ import { useNavigate } from "react-router-dom";
 import { useTimetableStore, Timetable } from "@/stores/useTimetableStore";
 import { ROUTES } from "@/constants/routes";
 import { useMemo, useCallback, useState } from "react";
+import { Pencil, Trash2 } from "lucide-react";
 import { ClassItem } from "@/components/mobile/timetable/TimetableGrid";
 import TimeTableCreateModal from "@/components/mobile/timetable/TimeTableCreateModal";
+import Modal from "@/components/common/Modal";
+import InputField from "@/components/common/InputField";
 import {
   useTimeTables,
   useUpdateTimeTablePrimary,
+  useUpdateTimeTableName,
+  useDeleteTimeTable,
 } from "@/hooks/useTimeTables";
 import { useSemesters } from "@/hooks/useSemesters";
 import { formatSemester, pickCurrentSemester } from "@/utils/semester";
@@ -51,6 +56,54 @@ export default function MobileTimeTableListPage() {
   useTimeTables();
   const { semesters: serverSemesters } = useSemesters();
   const updatePrimaryMutation = useUpdateTimeTablePrimary();
+  const updateNameMutation = useUpdateTimeTableName();
+  const deleteMutation = useDeleteTimeTable();
+
+  // 이름 변경/삭제(#252). 그리드 화면(MobileTimeTablePage)에는 있었지만 여러
+  // 시간표를 한 눈에 보는 이 목록 화면에는 관리 동작이 아예 없었다 - 같은
+  // mutation을 그대로 재사용한다.
+  const [renameTarget, setRenameTarget] = useState<Timetable | null>(null);
+  const [renameInputVal, setRenameInputVal] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<Timetable | null>(null);
+
+  const openRenameModal = (t: Timetable) => {
+    setRenameInputVal(t.name);
+    setRenameTarget(t);
+  };
+
+  const handleRenameConfirm = () => {
+    if (!renameTarget || !renameInputVal.trim()) return;
+    updateNameMutation.mutate(
+      { timeTableId: renameTarget.id, timeTableName: renameInputVal.trim() },
+      {
+        onSuccess: () => {
+          mixpanelTrack.timetableActionCompleted("이름 변경", {
+            semester: renameTarget.semester,
+          });
+          setRenameTarget(null);
+        },
+        onError: (error: any) => {
+          alert(error.response?.data?.msg || "시간표 이름 변경에 실패했습니다.");
+        },
+      },
+    );
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTarget || deleteMutation.isPending) return;
+    deleteMutation.mutate(deleteTarget.id, {
+      onSuccess: () => {
+        mixpanelTrack.timetableActionCompleted("삭제", {
+          semester: deleteTarget.semester,
+          course_count: deleteTarget.events.length,
+        });
+        setDeleteTarget(null);
+      },
+      onError: (error: any) => {
+        alert(error.response?.data?.msg || "시간표 삭제에 실패했습니다.");
+      },
+    });
+  };
 
   const handleSetPrimary = (t: Timetable) => {
     if (t.isRepresentative || updatePrimaryMutation.isPending) return;
@@ -159,6 +212,24 @@ export default function MobileTimeTableListPage() {
                       <ScheduleName>{t.name}</ScheduleName>
                       <TimetableMeta>
                         <CreditBadge>{getTimetableCredits(t.events)}학점</CreditBadge>
+                        <RowIconButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            openRenameModal(t);
+                          }}
+                          aria-label="이름 변경"
+                        >
+                          <Pencil size={16} />
+                        </RowIconButton>
+                        <RowIconButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setDeleteTarget(t);
+                          }}
+                          aria-label="삭제"
+                        >
+                          <Trash2 size={16} />
+                        </RowIconButton>
                         <StarButton onClick={(e) => {
                           e.stopPropagation();
                           handleSetPrimary(t);
@@ -183,6 +254,46 @@ export default function MobileTimeTableListPage() {
         isOpen={isAddModalOpen}
         onClose={() => setIsAddModalOpen(false)}
         initialSemester={addModalSemester}
+      />
+
+      <Modal
+        isOpen={renameTarget !== null}
+        onClose={() => setRenameTarget(null)}
+        title="시간표 이름 변경"
+        primaryButton={{
+          text: "변경",
+          variant: "brand",
+          onClick: handleRenameConfirm,
+          disabled: !renameInputVal.trim() || updateNameMutation.isPending,
+        }}
+        secondaryButton={{
+          text: "취소",
+          onClick: () => setRenameTarget(null),
+        }}
+      >
+        <InputField
+          label="시간표 이름"
+          value={renameInputVal}
+          onChange={setRenameInputVal}
+          placeholder="시간표 이름을 입력하세요"
+        />
+      </Modal>
+
+      <Modal
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        title="시간표 삭제"
+        description={`"${deleteTarget?.name ?? ""}" 시간표를 삭제하면\n복구할 수 없습니다. 삭제하시겠습니까?`}
+        primaryButton={{
+          text: "삭제",
+          variant: "danger",
+          onClick: handleDeleteConfirm,
+          disabled: deleteMutation.isPending,
+        }}
+        secondaryButton={{
+          text: "취소",
+          onClick: () => setDeleteTarget(null),
+        }}
       />
     </PageWrapper>
   );
@@ -300,6 +411,19 @@ const StarButton = styled.button`
   border: none;
   cursor: pointer;
   outline: none;
+`;
+
+const RowIconButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  outline: none;
+  color: var(--text-tertiary, #8b95a1);
 `;
 
 const EmptySemesterWrapper = styled.div`


### PR DESCRIPTION
## 요약
이슈 조사에서 확인된 구체적 공백을 메웁니다: 그리드 화면(`MobileTimeTablePage`)에는 시간표 이름 변경/삭제가 있었지만, 여러 학기의 시간표를 한 눈에 보는 목록 화면에는 관리 동작이 아예 없어 결국 그리드로 들어가야 했습니다.

## 변경 사항
- 각 행에 연필(이름 변경)/휴지통(삭제) 아이콘 버튼 추가.
- `useUpdateTimeTableName`/`useDeleteTimeTable`를 그대로 재사용 — 그리드 화면과 동일한 `Modal` 컴포넌트·확인 문구·mixpanel 이벤트 패턴을 따릅니다.

## 이슈 완료 조건 중 남은 부분
"목록 화면 개선 방향(디자인/기획) 확정"은 여전히 미확인 상태입니다 — 이번 변경은 이슈 조사에서 명시적으로 드러난 기능 공백(관리 동작 부재)만 메운 것이고, 레이아웃/시각적 개편 자체는 다루지 않습니다. 디자인 방향이 정해지기 전에는 코드로 임의로 결정할 수 없다고 판단했습니다. 이 PR 머지 후에도 #252는 열어둘 예정입니다.

## 확인
- `tsc --noEmit`, `npm run build` 통과
- eslint(레거시 설정): `no-explicit-any` 3건 — 그리드 화면의 기존 `onError: (error: any)` 패턴을 그대로 따른 것으로, 이 파일에 이미 있던 동일 패턴(1건)에 2건이 늘어난 것입니다. 새 카테고리의 문제는 아닙니다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>