### PR TITLE
fix: 성적 붙여넣기 학점 안내 문구 추가 (#316)

### DIFF
--- a/src/components/mobile/timetable/GradeImportSheet.tsx
+++ b/src/components/mobile/timetable/GradeImportSheet.tsx
@@ -219,6 +219,13 @@ export default function GradeImportSheet({
                         빠집니다.
                       </span>
                     )}
+                    {matchedCount > 0 && (
+                      <span className="target">
+                        학점은 현재 편람 기준으로 표시돼요. 이수 당시와
+                        학점이 바뀐 과목은 실제와 다를 수 있어요 — 다르면
+                        직접 수정해주세요.
+                      </span>
+                    )}
                     <span className="target">
                       {targetSemesterLabel}에 추가됩니다.
                     </span>


### PR DESCRIPTION
## 원인
`resolveGradeCourses.ts`가 과목명으로 매칭할 때(대부분의 행) 쓰는 학점은 `GET /api/courses`의 `Course.credit`입니다. 이 카탈로그는 학기별 이력이 아니라 "현재" 값 하나만 갖고 있어서, 커리큘럼 개편으로 과목 학점이 바뀐 경우 과거 학기 성적을 붙여넣어도 항상 최신(현재) 학점으로 표시됩니다. 개설강의 학수번호로 재조회하는 2단계는 이름 매칭이 애매한 행에만 돌고(대부분 행은 1단계에서 이미 확정), dev 서버에는 최신 학기 개설강의만 동기화돼 있어 과거 학기는 그마저도 대부분 실패합니다 — 즉 프론트가 지금 갖고 있는 데이터로는 과거 시점의 정확한 학점을 알아낼 방법이 없습니다.

## 조치
사용자님이 이슈에서 제안하신 대로 안내 문구를 추가했습니다: "학점은 현재 편람 기준으로 표시돼요. 이수 당시와 학점이 바뀐 과목은 실제와 다를 수 있어요 — 다르면 직접 수정해주세요." 적용 후 성적 계산기 메인 테이블에서 학점 칸이 이미 직접 수정 가능한 입력 필드임을 확인했습니다.

## 확인
- `tsc --noEmit`, `npm run build` 통과
- 변경 파일 eslint(레거시 설정) 통과

Closes #316

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>