### PR TITLE
fix: 게시글/댓글 작성자 차단이 실제로 동작하도록 수정 (#294)

### DIFF
--- a/src/apis/blocks.ts
+++ b/src/apis/blocks.ts
@@ -15,6 +15,37 @@ export const blockUser = async (
 };
 
 /**
+ * 게시글 작성자 차단 (postId 기준).
+ *
+ * PostResponseDto/PostListResponseDto는 memberId를 내려주지 않는다(익명 글 재식별
+ * 방지, server 확인 완료 — /v3/api-docs 스키마에 memberId 필드 자체가 없음). 그래서
+ * blockUser(memberId)는 애초에 호출할 수 없었다 - 게시글 작성자 차단 버튼이 있어도
+ * 항상 조용히 실패(또는 아예 노출 안 됨)하던 상태였다. postId만으로 서버가 작성자를
+ * 찾아 차단하는 이 엔드포인트를 대신 쓴다.
+ */
+export const blockPostAuthor = async (
+  postId: number,
+): Promise<ApiResponse<void>> => {
+  const response = await tokenInstance.post<ApiResponse<void>>(
+    `/api/blocks/by-post/${postId}`,
+  );
+  return response.data;
+};
+
+/**
+ * 댓글/대댓글 작성자 차단 (replyId 기준). blockPostAuthor와 같은 이유로 필요하다 —
+ * ReplyResponseDto/ReReplyResponseDto에도 memberId가 없다.
+ */
+export const blockReplyAuthor = async (
+  replyId: number,
+): Promise<ApiResponse<void>> => {
+  const response = await tokenInstance.post<ApiResponse<void>>(
+    `/api/blocks/by-reply/${replyId}`,
+  );
+  return response.data;
+};
+
+/**
  * 차단 해제
  */
 export const unblockUser = async (

--- a/src/components/mobile/moderation/BlockUserModal.tsx
+++ b/src/components/mobile/moderation/BlockUserModal.tsx
@@ -1,18 +1,20 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Modal from "@/components/common/Modal";
-import { blockUser } from "@/apis/blocks";
+import { blockPostAuthor, blockReplyAuthor } from "@/apis/blocks";
 
-export interface BlockTarget {
-  memberId: number;
-  nickname: string;
-}
+// postId/replyId 기준으로만 차단한다 — PostResponseDto/ReplyResponseDto가
+// memberId를 내려주지 않아(익명 글/댓글 재식별 방지) 클라이언트는 애초에
+// memberId를 알 수 없다. 서버가 postId/replyId로 작성자를 찾아 차단한다.
+export type BlockTarget =
+  | { postId: number; nickname: string }
+  | { replyId: number; nickname: string };
 
 interface BlockUserModalProps {
   /** null 이면 닫힌 상태 */
   target: BlockTarget | null;
   onClose: () => void;
-  /** 차단 성공 후 차단된 memberId와 함께 호출 (목록/상세 새로고침 등) */
-  onBlocked?: (blockedMemberId: number) => void;
+  /** 차단 성공 후 호출. target이 post였는지 reply였는지는 호출부가 target으로 직접 판단한다. */
+  onBlocked?: () => void;
 }
 
 export default function BlockUserModal({
@@ -23,15 +25,16 @@ export default function BlockUserModal({
   const queryClient = useQueryClient();
 
   const blockMutation = useMutation({
-    mutationFn: (targetMemberId: number) => blockUser(targetMemberId),
-    onSuccess: (_data, blockedMemberId) => {
+    mutationFn: (t: BlockTarget) =>
+      "postId" in t ? blockPostAuthor(t.postId) : blockReplyAuthor(t.replyId),
+    onSuccess: () => {
       alert(
         "차단했습니다.\n차단한 사용자의 글과 댓글은 더 이상 보이지 않습니다.",
       );
       queryClient.invalidateQueries({ queryKey: ["blockedUsers"] });
       queryClient.invalidateQueries({ queryKey: ["userProfile"] });
       onClose();
-      onBlocked?.(blockedMemberId);
+      onBlocked?.();
     },
     onError: (error: unknown) => {
       console.error("유저 차단 실패", error);
@@ -52,7 +55,7 @@ export default function BlockUserModal({
       }
       primaryButton={{
         text: "차단하기",
-        onClick: () => target && blockMutation.mutate(target.memberId),
+        onClick: () => target && blockMutation.mutate(target),
         variant: "danger",
         disabled: !target || blockMutation.isPending,
         loading: blockMutation.isPending,

--- a/src/containers/mobile/postdetail/CommentListContainer.tsx
+++ b/src/containers/mobile/postdetail/CommentListContainer.tsx
@@ -24,7 +24,7 @@ interface CommentListProps {
   setReplyContent: (content: string) => void;
   onCommentUpdate: () => void;
   onReportReply: (reply: Reply) => void;
-  onBlockWriter: (memberId: number, nickname: string) => void;
+  onBlockWriter: (replyId: number, nickname: string) => void;
 }
 
 export default function CommentListMobile({
@@ -127,18 +127,16 @@ export default function CommentListMobile({
                 >
                   신고
                 </DropdownItem>
-                {/* 익명 댓글은 memberId가 없어 차단 대상을 특정할 수 없다. */}
-                {!reply.isAnonymous && reply.memberId && (
-                  <DropdownItem
-                    $danger
-                    onClick={() => {
-                      setActiveMenuId(null);
-                      onBlockWriter(reply.memberId!, reply.writer || "작성자");
-                    }}
-                  >
-                    차단
-                  </DropdownItem>
-                )}
+                {/* replyId만으로 서버가 작성자를 찾아 차단하므로(#294) 익명 댓글도 차단 가능하다. */}
+                <DropdownItem
+                  $danger
+                  onClick={() => {
+                    setActiveMenuId(null);
+                    onBlockWriter(reply.id, reply.writer || "작성자");
+                  }}
+                >
+                  차단
+                </DropdownItem>
               </>
             )}
           </DropdownMenu>

--- a/src/pages/mobile/MobilePostDetailPage.tsx
+++ b/src/pages/mobile/MobilePostDetailPage.tsx
@@ -158,9 +158,14 @@ export default function PostDetailPage() {
     setReportTarget({ type: "REPLY", postId: post.id, replyId: reply.id });
   };
 
-  const handleBlockAuthor = (memberId: number, nickname: string) => {
+  const handleBlockPostAuthor = (postId: number, nickname: string) => {
     if (!requireLogin()) return;
-    setBlockTarget({ memberId, nickname });
+    setBlockTarget({ postId, nickname });
+  };
+
+  const handleBlockReplyAuthor = (replyId: number, nickname: string) => {
+    if (!requireLogin()) return;
+    setBlockTarget({ replyId, nickname });
   };
 
   const headerMenu = useMemo(() => {
@@ -186,13 +191,11 @@ export default function PostDetailPage() {
       },
     ];
 
-    // 익명 게시글은 memberId가 내려오지 않아 차단 대상을 특정할 수 없다.
-    if (post.memberId) {
-      menu.push({
-        label: "작성자 차단하기",
-        onClick: () => handleBlockAuthor(post.memberId!, post.writer || "작성자"),
-      });
-    }
+    // postId만으로 서버가 작성자를 찾아 차단하므로(#294) 익명 글도 차단 가능하다.
+    menu.push({
+      label: "작성자 차단하기",
+      onClick: () => handleBlockPostAuthor(post.id, post.writer || "작성자"),
+    });
 
     return menu;
   }, [post, navigate, isLoggedIn]);
@@ -224,7 +227,7 @@ export default function PostDetailPage() {
                 setReplyContent={setReplyContent}
                 onCommentUpdate={() => setCommentUpdated(true)}
                 onReportReply={handleReportReply}
-                onBlockWriter={handleBlockAuthor}
+                onBlockWriter={handleBlockReplyAuthor}
               />
             </CommentWrapper>
           </PostWrapper>
@@ -250,11 +253,12 @@ export default function PostDetailPage() {
           <BlockUserModal
             target={blockTarget}
             onClose={() => setBlockTarget(null)}
-            onBlocked={(blockedMemberId) => {
+            onBlocked={() => {
               // 차단 직후 해당 작성자의 글/댓글이 더 이상 보이지 않아야 한다.
               // 글쓴이를 차단했다면 이 상세 페이지 자체를 벗어나고,
-              // 댓글 작성자를 차단했다면 목록만 다시 불러온다.
-              if (post.memberId === blockedMemberId) {
+              // 댓글 작성자를 차단했다면 목록만 다시 불러온다. blockTarget이
+              // postId/replyId 중 무엇이었는지로 직접 판단한다(응답에 값이 없다).
+              if (blockTarget && "postId" in blockTarget) {
                 navigate(-1);
               } else {
                 setCommentUpdated(true);


### PR DESCRIPTION
## 발견
서버 조사 중 확인했습니다: `PostResponseDto`/`PostListResponseDto`/`ReplyResponseDto`/`ReReplyResponseDto` 어디에도 `memberId`가 없습니다(서버 스웨거 스키마로 확인). 이 화면의 "작성자 차단하기"는 `post.memberId`/`reply.memberId`가 있을 때만 노출되도록 짜여 있었는데, 그 값이 항상 `undefined`였습니다 — App Store 심사 대응(#294/#295)으로 만든 안전장치가 배포 이후 한 번도 나타난 적이 없었습니다.

## 조치
서버에 추가한(`inu-portal-server` PR #368, 머지됨) postId/replyId 기반 차단 엔드포인트를 쓰도록 바꿨습니다.

- `apis/blocks.ts`: `blockPostAuthor(postId)`/`blockReplyAuthor(replyId)` 추가.
- `BlockUserModal`: target을 `{ memberId }` 대신 `{ postId } | { replyId }`로 받아 알맞은 API를 호출하도록 재설계.
- `MobilePostDetailPage`: "작성자 차단하기" 메뉴 노출 조건에서 `post.memberId` 가드 제거 — 이제 postId만 있으면 되므로 익명 글도 가능합니다.
- `CommentListContainer`: 댓글/대댓글 차단 버튼의 `memberId` 가드도 동일하게 제거.

## 확인
- `tsc --noEmit`, `npm run build` 통과
- eslint(레거시 설정) — `MobilePostDetailPage`의 기존 useMemo 메모이제이션 경고는 이 변경 전에도 있던 패턴(오히려 조건 분기 하나가 줄어 경고 수는 9→7로 감소)

이 PR은 대응하는 서버 PR(inu-appcenter/inu-portal-server#368, 이미 머지됨)이 있어야 실제로 동작합니다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>