### PR TITLE
fix: 좋아요/스크랩 시 게시글·댓글 리스트 캐시 미반영 수정

### DIFF
--- a/src/components/desktop/posts/LikeScrapButtons.tsx
+++ b/src/components/desktop/posts/LikeScrapButtons.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
+import { useQueryClient } from "@tanstack/react-query";
 import heartEmpty from "@/resources/assets/posts/heart-empty.svg";
 import heartFilled from "@/resources/assets/posts/heart-filled.svg";
 import scrapEmpty from "@/resources/assets/posts/scrap-empty.svg";
@@ -34,6 +35,7 @@ export default function LikeScrapButtons({
   const [showDropdown, setShowDropdown] = useState(false);
   const [selectedReason, setSelectedReason] = useState("");
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { tokenInfo } = useUserStore();
   const isLoggedIn = Boolean(tokenInfo.accessToken);
 
@@ -67,6 +69,9 @@ export default function LikeScrapButtons({
         setLikeState(likeState - 1);
         setIsLikedState(!isLikedState);
       }
+      // 게시글 리스트가 들고 있는 캐시된 like 값은 이 컴포넌트의 로컬
+      // state와 별개라 갱신되지 않는다. 리스트를 다시 불러오도록 무효화한다.
+      queryClient.invalidateQueries({ queryKey: ["posts"] });
     } catch (error) {
       console.error("게시글 좋아요 여부 변경 실패", error);
       // refreshError가 아닌 경우 처리
@@ -104,6 +109,9 @@ export default function LikeScrapButtons({
         setScrapState(scrapState - 1);
         setIsScrapedState(!isScrapedState);
       }
+      // 게시글 리스트가 들고 있는 캐시된 scrap 값은 이 컴포넌트의 로컬
+      // state와 별개라 갱신되지 않는다. 리스트를 다시 불러오도록 무효화한다.
+      queryClient.invalidateQueries({ queryKey: ["posts"] });
     } catch (error) {
       console.error("스크랩 여부 변경 실패", error);
       // refreshError가 아닌 경우 처리

--- a/src/components/desktop/posts/PostsList.tsx
+++ b/src/components/desktop/posts/PostsList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -14,15 +14,12 @@ import {
 } from "@/apis/notices";
 import { getSearch } from "@/apis/search";
 import { getPosts } from "@/apis/posts";
-import { Post } from "@/types/posts";
 import heart from "@/resources/assets/posts/posts-heart.svg";
 import { formatTimeAgo } from "@/utils/date";
 
 export default function PostsList() {
   const location = useLocation();
   const navigate = useNavigate();
-  const [posts, setPosts] = useState<Post[]>([]);
-  const [pages, setPages] = useState(1);
 
   const params = useMemo(
     () => new URLSearchParams(location.search),
@@ -45,41 +42,19 @@ export default function PostsList() {
     placeholderData: keepPreviousData,
   });
 
-  useEffect(() => {
-    if (isNoticeType) {
-      return;
-    }
-
-    let isCancelled = false;
-
-    const fetchPosts = async () => {
-      try {
-        const response = query
-          ? await getSearch(query, sort, page)
-          : await getPosts(category, sort, page);
-
-        if (isCancelled) {
-          return;
-        }
-
-        setPosts(response.data.contents);
-        setPages(response.data.pages);
-      } catch (error) {
-        if (!isCancelled) {
-          console.error("게시글/공지 가져오기 실패", error);
-        }
-      }
-    };
-
-    fetchPosts();
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [category, isNoticeType, page, query, sort]);
+  const { data: postsResponse } = useQuery({
+    queryKey: ["posts", "desktop", category, sort, page, query],
+    queryFn: () =>
+      query ? getSearch(query, sort, page) : getPosts(category, sort, page),
+    enabled: !isNoticeType,
+    placeholderData: keepPreviousData,
+  });
 
   const notices = noticeResponse?.data.contents ?? [];
-  const totalPages = isNoticeType ? noticeResponse?.data.pages ?? page : pages;
+  const posts = postsResponse?.data.contents ?? [];
+  const totalPages = isNoticeType
+    ? (noticeResponse?.data.pages ?? page)
+    : (postsResponse?.data.pages ?? page);
 
   const handleClickPost = (postId: number) => {
     const nextParams = new URLSearchParams(location.search);

--- a/src/components/desktop/posts/ReplyLikeButton.tsx
+++ b/src/components/desktop/posts/ReplyLikeButton.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
+import { useQueryClient } from "@tanstack/react-query";
 import heartEmpty from "@/resources/assets/posts/heart-empty.svg";
 import heartFilled from "@/resources/assets/posts/heart-filled.svg";
 import { putReplyLike } from "@/apis/replies";
@@ -12,6 +13,18 @@ interface Props {
 }
 
 export default function ReplyLikeButton({ id, like, isLiked }: Props) {
+  const [likeState, setLikeState] = useState(like);
+  const [isLikedState, setIsLikedState] = useState(isLiked);
+  const queryClient = useQueryClient();
+
+  // 댓글은 reply.id가 key라 부모가 새 데이터를 내려줘도 리마운트되지
+  // 않는다. props가 바뀌면 로컬 state를 재동기화해서, 서버에서 다시
+  // 받아온 최신 값에 이 버튼이 계속 박제되지 않도록 한다.
+  useEffect(() => {
+    setLikeState(like);
+    setIsLikedState(isLiked);
+  }, [like, isLiked]);
+
   const handleLike = async () => {
     try {
       const response = await putReplyLike(id);
@@ -22,6 +35,7 @@ export default function ReplyLikeButton({ id, like, isLiked }: Props) {
         setLikeState(likeState - 1);
         setIsLikedState(!isLikedState);
       }
+      queryClient.invalidateQueries({ queryKey: ["posts"] });
     } catch (error) {
       console.error("댓글 좋아요 여부 변경 실패", error);
       // refreshError가 아닌 경우 처리
@@ -45,8 +59,6 @@ export default function ReplyLikeButton({ id, like, isLiked }: Props) {
     }
   };
 
-  const [likeState, setLikeState] = useState(like);
-  const [isLikedState, setIsLikedState] = useState(isLiked);
   return (
     <ReplyLikeButtonWrapper>
       <img

--- a/src/components/mobile/postdetail/util/m.postlike.tsx
+++ b/src/components/mobile/postdetail/util/m.postlike.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Heart } from "lucide-react";
 import styled from "styled-components";
+import { useQueryClient } from "@tanstack/react-query";
 import { ROUTES } from "@/constants/routes";
 import { putLike } from "@/apis/posts";
 import useUserStore from "@/stores/useUserStore";
@@ -17,6 +18,7 @@ export default function PostLike({ id, like, isLikedProp }: PostLikeProps) {
   const [likeState, setLikeState] = useState(like);
   const [isLikedState, setIsLikedState] = useState(isLikedProp);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { tokenInfo } = useUserStore();
   const isLoggedIn = Boolean(tokenInfo.accessToken);
 
@@ -55,6 +57,11 @@ export default function PostLike({ id, like, isLikedProp }: PostLikeProps) {
         setLikeState(likeState - 1);
         setIsLikedState(!isLikedState);
       }
+      // 게시글 리스트(마이페이지, 커뮤니티 목록 등)가 들고 있는 캐시된 like
+      // 값은 이 컴포넌트의 로컬 state와 별개라 갱신되지 않는다. 리스트를
+      // 다시 불러오도록 무효화한다. (queryKey 접두사 매칭으로
+      // ["posts","mobile",category] 등도 함께 무효화됨)
+      queryClient.invalidateQueries({ queryKey: ["posts"] });
     } catch (error) {
       console.error("게시글 좋아요 여부 변경 실패", error);
       if (

--- a/src/components/mobile/postdetail/util/m.postscrap.tsx
+++ b/src/components/mobile/postdetail/util/m.postscrap.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Bookmark } from "lucide-react";
 import styled from "styled-components";
+import { useQueryClient } from "@tanstack/react-query";
 import { ROUTES } from "@/constants/routes";
 import { putScrap } from "@/apis/posts";
 import useUserStore from "@/stores/useUserStore";
@@ -21,6 +22,7 @@ export default function PostScrap({
   const [scrapState, setScrapState] = useState(scrap);
   const [isScrapedState, setIsScrapedState] = useState(isScrapedProp);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { tokenInfo } = useUserStore();
   const isLoggedIn = Boolean(tokenInfo.accessToken);
 
@@ -59,6 +61,10 @@ export default function PostScrap({
         setScrapState(scrapState - 1);
         setIsScrapedState(!isScrapedState);
       }
+      // 게시글 리스트(마이페이지, 커뮤니티 목록 등)가 들고 있는 캐시된 scrap
+      // 값은 이 컴포넌트의 로컬 state와 별개라 갱신되지 않는다. 리스트를
+      // 다시 불러오도록 무효화한다.
+      queryClient.invalidateQueries({ queryKey: ["posts"] });
     } catch (error) {
       console.error("스크랩 여부 변경 실패", error);
       if (


### PR DESCRIPTION
## 문제

Closes #323

게시글 상세에서 좋아요(또는 스크랩/댓글 좋아요)를 누르고 리스트로 돌아가면 카운트가 반영되어 있지 않았다.

## 원인

좋아요/스크랩 버튼이 API 응답을 컴포넌트 로컬 `useState`에만 반영하고, 리스트가 들고 있는 React Query 캐시(`queryKey: ["posts", ...]`)는 전혀 건드리지 않았다. 글쓰기/삭제 경로에는 이미 `invalidateQueries({queryKey:["posts"]})` 패턴이 있었지만 좋아요/스크랩/댓글 좋아요에는 빠져 있었다.

데스크톱 `/posts` 리스트는 한술 더 떠 React Query 자체를 안 쓰고 `useEffect` 1회성 fetch였어서, 무효화할 캐시가 아예 없었다.

자세한 분석은 #323 이슈 본문과 댓글 참고.

## 변경 사항

- `m.postlike.tsx` / `m.postscrap.tsx` (모바일), `LikeScrapButtons.tsx` (데스크톱): 성공 시 `queryClient.invalidateQueries({queryKey:["posts"]})` 호출.
- `PostsList.tsx` (데스크톱 `/posts` 리스트): 캐시 없는 `useEffect` fetch를 `useQuery`로 전환 — 이게 있어야 위 invalidate가 실제로 리스트를 refetch한다.
- `ReplyLikeButton.tsx` (댓글/대댓글, 모바일·데스크톱 공용):
  - 좋아요 게시글과 동일하게 `invalidateQueries` 추가.
  - `PostLike`에는 있었지만 이 컴포넌트엔 없던 prop 재동기화 `useEffect` 추가. `reply.id`가 key라 리마운트되지 않아, 서버가 다시 내려준 최신 `like`/`isLiked`로 절대 갱신되지 않던 버그도 함께 수정.

## 확인

- `npx tsc --noEmit` 통과
- `npm run build` 통과
- (참고) `npm run lint`는 이 브랜치와 무관하게 `dev`에서도 이미 실패한다 — 설치된 `eslint`가 9.x인데 레포는 구형 `.eslintrc.cjs`를 쓰고 있어 발생하는 기존 환경 이슈.
